### PR TITLE
Add milestone to list of ansible versions

### DIFF
--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -16,6 +16,7 @@ jobs:
           - stable-2.11
           - stable-2.12
           - stable-2.13
+          - milestone
           - devel
         python-version:
           - "3.8"

--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -1,6 +1,7 @@
 name: Sanity tests
 on:
   workflow_call:
+
 jobs:
   sanity:
     env:

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -11,17 +11,18 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version:
-          - "3.8"
-          - "3.9"
-          - "3.10"
         ansible-version:
           - stable-2.9
           - stable-2.10
           - stable-2.11
           - stable-2.12
           - stable-2.13
+          - milestone
           - devel
+        python-version:
+          - "3.8"
+          - "3.9"
+          - "3.10"
         netcommon-version:
           - galaxy
           - github


### PR DESCRIPTION
We run against this in zuul today, and it's probably a good idea to keep it.