### PR TITLE
Allow ansible-lint to run against all files

### DIFF
--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -9,5 +9,3 @@ jobs:
       - uses: actions/checkout@v3
       - name: Run ansible-lint
         uses: ansible-community/ansible-lint-action@main
-        with:
-          path: "tests/integration"


### PR DESCRIPTION
- Remove the limit of just running ansible-lint in the test/integration directory
- This will catch yaml formatting issues in changelog, galaxy issues etc.


e.g. https://github.com/ansible-collections/cisco.nxos/pull/525