### PR TITLE
Specify ref for checkout

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -10,6 +10,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           path: ${{ env.source_directory }}
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: "0"
       - name: Ensure a new changelog entry exists
         run: >-

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -57,6 +57,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           path: ${{ env.source_directory }}
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: "0"
 
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/integration_simple.yml
+++ b/.github/workflows/integration_simple.yml
@@ -79,6 +79,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           path: ${{ env.source_directory }}
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: "0"
 
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -117,6 +117,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           path: ${{ env.source_directory }}
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: "0"
 
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/unit_galaxy.yml
+++ b/.github/workflows/unit_galaxy.yml
@@ -118,6 +118,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           path: ${{ env.source_directory }}
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: "0"
 
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/unit_source.yml
+++ b/.github/workflows/unit_source.yml
@@ -110,6 +110,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           path: ${{ env.source_directory }}
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: "0"
 
       - name: Set up Python ${{ matrix.python-version }}


### PR DESCRIPTION
This specifies the ref for the repo checkout.

From the following: https://securitylab.github.com/research/github-actions-preventing-pwn-requests/

When the repo secrets are needed in a PR from a branch in a fork, the `pull_request_target` event needs to be used rather than simply pull request.  This may be the case for integration tests that need repo secrets for CML or to make a new branch in the repo like the ansible.scm integration tests do.

By default: (https://github.com/actions/checkout)
```
# The branch, tag or SHA to checkout. When checking out the repository that
# triggered a workflow, this defaults to the reference or SHA for that event.
# Otherwise, uses the default branch.
ref: ''
```

This works fine when the event is `pull_request`, but in the case of `pull_reqeust_target`:

```
We have also noticed a pattern that has a vulnerable intent of use, however due to misunderstanding of pull_request_target ends up being a broken, but not vulnerable, workflow. In these cases, repositories switched to using the pull_request_target trigger, but use the default values for the actions/checkout action, 
```

ref: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target


This should be used in conjunction with a change in the calling repo to check for a label:

(being tested here)

https://github.com/ansible-network/ansible.scm/pull/19
