### PR TITLE
Allow for a PR to not have a change log, use label "skip-changelog"

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -12,9 +12,13 @@ jobs:
           path: ${{ env.source_directory }}
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: "0"
+        if: "!contains(github.event.pull_request.labels.*.name, 'skip changelog')"
+
       - name: Ensure a new changelog entry exists
         run: >-
           git show origin/${{ github.event.pull_request.base.ref }}..HEAD
           --name-status
           --oneline |
           grep -E -e "A\s+changelogs/fragments/" -e "M\s+CHANGELOG.rst"
+        if: "!contains(github.event.pull_request.labels.*.name, 'skip changelog')"
+

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -12,7 +12,7 @@ jobs:
           path: ${{ env.source_directory }}
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: "0"
-        if: "!contains(github.event.pull_request.labels.*.name, 'skip changelog')"
+        if: "!contains(github.event.pull_request.labels.*.name, 'skip-changelog')"
 
       - name: Ensure a new changelog entry exists
         run: >-
@@ -20,5 +20,5 @@ jobs:
           --name-status
           --oneline |
           grep -E -e "A\s+changelogs/fragments/" -e "M\s+CHANGELOG.rst"
-        if: "!contains(github.event.pull_request.labels.*.name, 'skip changelog')"
+        if: "!contains(github.event.pull_request.labels.*.name, 'skip-changelog')"
 


### PR DESCRIPTION
If a PR has a "skip-changelog" label, skip the test for the changelog