### PR TITLE
Add auto safe to test

### DIFF
--- a/.github/workflows/auto-safe-to-test.yml
+++ b/.github/workflows/auto-safe-to-test.yml
@@ -1,0 +1,36 @@
+name: auto-safe-to-test
+on:
+  workflow_call:
+
+jobs:
+  auto-safe-to-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v3
+        if: github.event_name != "labeled"
+     
+      - name: Remove the 'safe to test' label
+        run: gh pr edit $PR_NUMBER --remove-label "safe to test"
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          PR_NUMBER: ${{ github.event.number }}
+        if: github.event_name != "labeled"
+
+      - name: Check if the PR author is a collaborator
+        id: authorization
+        run: 'gh api -H "Accept: application/vnd.github.v3+json" $API_URL'
+        continue-on-error: true
+        env:
+          API_URL: /repos/${{ github.repository }}/collaborators/${{ github.actor }}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+        if: github.event_name != "labeled"
+
+      - name: Only if the check passed, set the label
+        run: gh pr edit $PR_NUMBER --add-label "safe to test"
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          PR_NUMBER: ${{ github.event.number }}
+        if: >-
+          steps.authorization.outcome == 'success' &&
+          github.event_name != "labeled" 


### PR DESCRIPTION
If correct, this should automatically:

1) Remove the label if the PR is from an outside contributor
2) Add the label if the PR is from a contributor

only if the event is not "labeled"