### PR TITLE
Add stable-2.14 branch to tests

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -42,6 +42,7 @@ jobs:
           # - stable-2.11
           # - stable-2.12
           - stable-2.13
+          # - stable-2.14
           # - milestone
           # - devel
         python-version:

--- a/.github/workflows/integration_simple.yml
+++ b/.github/workflows/integration_simple.yml
@@ -31,6 +31,10 @@ on:
               "python-version": "3.10"
             },
             {
+              "ansible-version": "stable-2.14",
+              "python-version": "3.8"
+            },
+            {
               "ansible-version": "milestone",
               "python-version": "3.8"
             },
@@ -64,6 +68,7 @@ jobs:
           - stable-2.11
           - stable-2.12
           - stable-2.13
+          - stable-2.14
           - milestone
           - devel
         python-version:

--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -59,6 +59,18 @@ on:
               "python-version": "3.7"
             },
             {
+              "ansible-version": "stable-2.14",
+              "python-version": "3.6"
+            },
+            {
+              "ansible-version": "stable-2.14",
+              "python-version": "3.7"
+            },
+            {
+              "ansible-version": "stable-2.14",
+              "python-version": "3.8"
+            },
+            {
               "ansible-version": "milestone",
               "python-version": "3.6"
             },
@@ -101,6 +113,7 @@ jobs:
           - stable-2.11
           - stable-2.12
           - stable-2.13
+          - stable-2.14
           - milestone
           - devel
         python-version:

--- a/.github/workflows/unit_galaxy.yml
+++ b/.github/workflows/unit_galaxy.yml
@@ -59,6 +59,18 @@ on:
               "python-version": "3.7"
             },
             {
+              "ansible-version": "stable-2.14",
+              "python-version": "3.6"
+            },
+            {
+              "ansible-version": "stable-2.14",
+              "python-version": "3.7"
+            },
+            {
+              "ansible-version": "stable-2.14",
+              "python-version": "3.8"
+            },
+            {
               "ansible-version": "milestone",
               "python-version": "3.6"
             },
@@ -101,6 +113,7 @@ jobs:
           - stable-2.11
           - stable-2.12
           - stable-2.13
+          - stable-2.14
           - milestone
           - devel
         python-version:

--- a/.github/workflows/unit_source.yml
+++ b/.github/workflows/unit_source.yml
@@ -52,6 +52,18 @@ on:
               "python-version": "3.7"
             },
             {
+              "ansible-version": "stable-2.14",
+              "python-version": "3.6"
+            },
+            {
+              "ansible-version": "stable-2.14",
+              "python-version": "3.7"
+            },
+            {
+              "ansible-version": "stable-2.14",
+              "python-version": "3.8"
+            },
+            {
               "ansible-version": "milestone",
               "python-version": "3.6"
             },
@@ -94,6 +106,7 @@ jobs:
           - stable-2.11
           - stable-2.12
           - stable-2.13
+          - stable-2.14
           - milestone
           - devel
         python-version:


### PR DESCRIPTION
`devel` is now 2.15 and `stable-2.14` has branched, so add the `stable-2.14` branch to tests.

Not sure if I've missed anything.