### PR TITLE
Ignore milestone on 3.11 for now

### DIFF
--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -16,6 +16,8 @@ on:
         # 2.13/3.11 not supported
         # 2.14/3.7 not supported
         # 2.14/3.8 not supported
+        # milestone/3.11 has a temporary issue
+        # related to a pinned dependency
         default: >-
           [
             {
@@ -77,6 +79,10 @@ on:
             {
               "ansible-version": "milestone",
               "python-version": "3.8"
+            },
+            {
+              "ansible-version": "milestone",
+              "python-version": "3.11"
             },
             {
               "ansible-version": "devel",


### PR DESCRIPTION
This can be reverted when https://github.com/ansible/ansible/blob/milestone/test/lib/ansible_test/_data/requirements/sanity.pylint.txt pins `dill==0.3.6` or greater