### PR TITLE
Make devel tests "optional"

### DIFF
--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -109,6 +109,7 @@ jobs:
         exclude: ${{ fromJSON(inputs.matrix_exclude) }}
         include: ${{ fromJSON(inputs.matrix_include) }}
     runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.ansible-version == 'devel' }}
 
     name: "py${{ matrix.python-version }} / ${{ matrix.os }} / ${{ matrix.ansible-version }}"
     steps:

--- a/.github/workflows/unit_galaxy.yml
+++ b/.github/workflows/unit_galaxy.yml
@@ -109,6 +109,7 @@ jobs:
         exclude: ${{ fromJSON(inputs.matrix_exclude) }}
         include: ${{ fromJSON(inputs.matrix_include) }}
     runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.ansible-version == 'devel' }}
 
     name: "py${{ matrix.python-version }} / ${{ matrix.os }} / ${{ matrix.ansible-version }}"
     steps:

--- a/.github/workflows/unit_source.yml
+++ b/.github/workflows/unit_source.yml
@@ -83,6 +83,7 @@ jobs:
           - "3.11"
         exclude: ${{ fromJSON(inputs.matrix_exclude) }}
     runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.ansible-version == 'devel' }}
 
     name: "py${{ matrix.python-version }} / ${{ matrix.os }} / ${{ matrix.ansible-version }}"
     steps:


### PR DESCRIPTION
The devel branch includes new tests and will break sanity tests with minimal notice.  While these issues generally still need fixing they shouldn't block folks from continuing to work on unrelated features.
By using "continue-on-error" we can allow devel sanity test failures to be "optional".  They'll still show up in the test results, however the 'status' of the workflow will count as successful.

~Forcefully overwriting the galaxy version information means that until a release has been tagged the sanity tests won't pick up deprecation which should have been removed already.  Since adding the tag actually performs the release this is *way* too late.~ (Moved to #48)