### PR TITLE
Don't forcibly rewrite the galaxy version.

### DIFF
--- a/.github/actions/identify_collection/action.yml
+++ b/.github/actions/identify_collection/action.yml
@@ -23,11 +23,6 @@ runs:
       run: pip3 install yq
       shell: bash
 
-    - name: Set the version number in galaxy.yml
-      run: yq -yi ".version=\"$(git describe --tags)\"" 'galaxy.yml'
-      shell: bash
-      working-directory: ${{ inputs.source_path }}
-
     - name: Extract metadata from galaxy.yml
       id: keys
       run: |


### PR DESCRIPTION
We shouldn't have `version: null` in our collections anymore, so this should be unnecessary now.