### PR TITLE
Fix issue with action identify_collection when galaxy.yml does not defined dependencies

### DIFF
--- a/.github/actions/identify_collection/action.yml
+++ b/.github/actions/identify_collection/action.yml
@@ -34,7 +34,7 @@ runs:
         echo "namespace=$(yq -r '.namespace' 'galaxy.yml')" >> $GITHUB_OUTPUT
         echo "name=$(yq -r '.name' 'galaxy.yml')" >> $GITHUB_OUTPUT
         echo "version=$(yq -r '.version' 'galaxy.yml')" >> $GITHUB_OUTPUT
-        echo "dependency=$(yq -r '.dependencies | keys | join(" ")' 'galaxy.yml')" >> $GITHUB_OUTPUT
+        echo "dependency=$(yq -r '.dependencies // [] | keys | join(" ")' 'galaxy.yml')" >> $GITHUB_OUTPUT
       shell: bash
       working-directory: ${{ inputs.source_path }}
 


### PR DESCRIPTION
error was `jq: error (at <stdin>:1): null (null) has no keys`