### PR TITLE
build_install_collection - fix install for collection that do not defined version in galaxy.yml

### DIFF
--- a/.github/actions/build_collection/action.yml
+++ b/.github/actions/build_collection/action.yml
@@ -1,0 +1,72 @@
+name: Build ansible collection
+description: |
+  This action generates a collection tarball from a directory source.
+  if required, action will execute playbook tools/prepare_release.yml and
+  generate-ansible-collection before building ansible collection.
+
+inputs:
+  source_path:
+    description: "Path to the collection directory to build"
+    default: "."
+outputs:
+  tar_file:
+    description: The path to the collection generated tarball
+    value: ${{ steps.identify.outputs.tar_file }}
+  collection_path:
+    description: The path where collection will be installed
+    value: ${{ steps.identify.outputs.collection_path }}
+
+runs:
+  using: composite
+  steps:
+    - name: install ansible-network/releases
+      run: pip install git+https://github.com/ansible-network/releases
+      shell: bash
+
+    - name: check if ansible-playbook is installed
+      id: ansible_check
+      shell: bash
+      run: |
+        if ! command -v ansible-playbook &> /dev/null; then
+          echo "ansible_installed=false" >> $GITHUB_OUTPUT
+        else
+          echo "ansible_installed=true" >> $GITHUB_OUTPUT
+        fi
+
+    - name: Install ansible-core (stable-2.12)
+      run: python3 -m pip install https://github.com/ansible/ansible/archive/stable-2.12.tar.gz --disable-pip-version-check
+      shell: bash
+      if: steps.ansible_check.outputs.ansible_installed == 'false'
+
+    - name: check if collection contains file tools/prepare_release.yml
+      id: prepare_release_check
+      shell: bash
+      run: |
+        if test -f "tools/prepare_release.yml"; then
+          echo "file_exists=true" >> $GITHUB_OUTPUT
+        else
+          echo "file_exists=false" >> $GITHUB_OUTPUT
+        fi
+      working-directory: ${{ inputs.source_path }}
+
+    - name: Run tools/prepare_release.yml
+      run: ansible-playbook tools/prepare_release.yml -v
+      shell: bash
+      working-directory: ${{ inputs.source_path }}
+      if: steps.prepare_release_check.outputs.file_exists == 'true'
+
+    - name: Generate version number for ansible collection
+      run: generate-ansible-collection
+      shell: bash
+      working-directory: ${{ inputs.source_path }}
+
+    - name: Read collection metadata from galaxy.yml
+      id: identify
+      uses: ansible-network/github_actions/.github/actions/identify_collection@main
+      with:
+        source_path: ${{ inputs.source_path }}
+
+    - name: Build collection
+      run: ansible-galaxy collection build -vvv
+      shell: bash
+      working-directory: ${{ inputs.source_path }}

--- a/.github/actions/build_install_collection/action.yml
+++ b/.github/actions/build_install_collection/action.yml
@@ -3,39 +3,57 @@ description: Build and install the collection
 
 inputs:
   install_python_dependencies:
-    description: "Install collection python dependencies"
-    required: true
+    description: "Whether to install collection python dependencies or not"
+    default: "true"
   source_path:
     description: "Path to the collection source"
-    required: true
+    default: "."
   collection_path:
     description: The final collection path
-    required: true
+    default: ""
   tar_file:
     description: The collection tarball when built
-    required: true
+    default: ""
 
 runs:
   using: composite
   steps:
-    - name: Show the galaxy.yml
-      run: cat galaxy.yml
-      shell: bash
-      working-directory: ${{ inputs.source_path }}
+    - uses: actions/checkout@v3
+      with:
+        path: "./.githubactions"
+
+    - name: Build ansible collection
+      id: build-collection
+      uses: ./.githubactions/.github/actions/build_collection
+      with:
+        source_path: ${{ inputs.source_path }}
 
     - name: Install bindep from pypi
       run: sudo python3 -m pip install bindep
       shell: bash
 
+    - name: check if bindep.txt exists
+      id: bindep_check
+      shell: bash
+      run: |
+        if test -f "bindep.txt"; then
+          echo "file_exists=true" >> $GITHUB_OUTPUT
+        else
+          echo "file_exists=false" >> $GITHUB_OUTPUT
+        fi
+      working-directory: ${{ inputs.source_path }}
+
     - name: Install missing system packages using bindep.txt
       run: bindep test | tail -n +2 | xargs sudo apt-get -o Debug::pkgProblemResolver=true -o Debug::Acquire::http=true install -y || exit 0
       shell: bash
       working-directory: ${{ inputs.source_path }}
+      if: steps.bindep_check.outputs.file_exists == 'true'
 
     - name: Check for missing system packages using bindep.txt
       run: bindep test
       shell: bash
       working-directory: ${{ inputs.source_path }}
+      if: steps.bindep_check.outputs.file_exists == 'true'
 
     - name: Install collection python requirements
       if: ${{ inputs.install_python_dependencies == 'true' }}
@@ -43,17 +61,12 @@ runs:
       shell: bash
       working-directory: ${{ inputs.source_path }}
 
-    - name: Build collection
-      run: ansible-galaxy collection build -vvv
-      shell: bash
-      working-directory: ${{ inputs.source_path }}
-
-    - name: Install collection and dependencies
-      run: ansible-galaxy collection install ./${{ inputs.tar_file }} -p /home/runner/collections
+    - name: Install collection
+      run: ansible-galaxy collection install ${{ steps.build-collection.outputs.tar_file }} -p /home/runner/collections
       shell: bash
       working-directory: ${{ inputs.source_path }}
 
     - name: Copy the galaxy.yml from source to destination, needed for pytest-ansible-units
-      run: cp galaxy.yml ${{ inputs.collection_path }}/galaxy.yml
+      run: cp galaxy.yml ${{ steps.build-collection.outputs.collection_path }}/galaxy.yml
       shell: bash
       working-directory: ${{ inputs.source_path }}

--- a/.github/actions/build_install_collection/action.yml
+++ b/.github/actions/build_install_collection/action.yml
@@ -15,6 +15,11 @@ inputs:
     description: The collection tarball when built
     default: ""
 
+outputs:
+  collection_path:
+    description: The final collection path
+    value: ${{ steps.build-collection.outputs.collection_path }}
+
 runs:
   using: composite
   steps:

--- a/.github/actions/build_install_collection/action.yml
+++ b/.github/actions/build_install_collection/action.yml
@@ -23,13 +23,9 @@ outputs:
 runs:
   using: composite
   steps:
-    - uses: actions/checkout@v3
-      with:
-        path: "./.githubactions"
-
-    - name: Build ansible collection
+    - name: Build collection
       id: build-collection
-      uses: ./.githubactions/.github/actions/build_collection
+      uses: abikouo/github_actions/.github/actions/build_collection@build_install_collection
       with:
         source_path: ${{ inputs.source_path }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,94 @@
+name: CI
+concurrency:
+  group: ${{ github.head_ref }}
+  cancel-in-progress: true
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - labeled
+      - unlabeled
+      - synchronize
+    branches:
+      - main
+      - stable-*
+    tags:
+      - "*"
+
+jobs:
+  build_collection:
+    runs-on: ubuntu-latest
+    env:
+      test_path: "./collection"
+    steps:
+      # Clone this repo
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      # Test with collection without 'version' in galaxy.xml (ansible-collections/cloud.common)
+      - name: Checkout collection to test
+        uses: actions/checkout@v3
+        with:
+          repository: ansible-collections/cloud.common
+          ref: 2.0.0
+          path: ${{ env.test_path }}
+
+      - name: Build ansible collection
+        id: build-collection
+        uses: ./.github/actions/build_collection
+        with:
+          source_path: ${{ env.test_path }}
+
+      - name: Ensure action output
+        run: |
+          [[ ${{ steps.build-collection.outputs.tar_file }} == "cloud-common-2.0.0.tar.gz" ]]
+        shell: bash
+
+      - name: Ensure collection was built as expected
+        run: |
+          test -f ${{ steps.build-collection.outputs.tar_file }}
+        shell: bash
+        working-directory: ${{ env.test_path }}
+
+  build_install_collection:
+    runs-on: ubuntu-latest
+    env:
+      test_path: "./collection"
+    steps:
+      # Clone this repo
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Checkout collection to test
+        uses: actions/checkout@v3
+        with:
+          repository: ansible-collections/kubernetes.core
+          ref: 2.4.0
+          path: ${{ env.test_path }}
+
+      - name: Build and install collection
+        uses: ./.github/actions/build_install_collection
+        with:
+          source_path: ${{ env.test_path }}
+
+      - name: create kubernetes cluster
+        uses: helm/kind-action@v1.4.0
+
+      - name: Execute playbook using collection installed
+        run: |
+          set -eux
+          echo "- hosts: localhost" > test_playbook.yaml
+          echo "  gather_facts: false" >> test_playbook.yaml
+          echo "  collections:" >> test_playbook.yaml
+          echo "    - kubernetes.core" >> test_playbook.yaml
+          echo "  vars:" >> test_playbook.yaml
+          echo "    ansible_python_interpreter: python3" >> test_playbook.yaml
+          echo "  tasks:" >> test_playbook.yaml
+          echo "    - name: ensure namespace" >> test_playbook.yaml
+          echo "      k8s:" >> test_playbook.yaml
+          echo "       kind: namespace" >> test_playbook.yaml
+          echo "       name: testing" >> test_playbook.yaml
+          ansible-playbook test_playbook -vvv
+        shell: bash

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -90,5 +90,5 @@ jobs:
           echo "      k8s:" >> test_playbook.yaml
           echo "       kind: namespace" >> test_playbook.yaml
           echo "       name: testing" >> test_playbook.yaml
-          ansible-playbook test_playbook -vvv
+          ansible-playbook test_playbook.yaml -vvv
         shell: bash


### PR DESCRIPTION
For some Ansible collections `cloud.common`, `vmware.vmware_rest`, etc, the `galaxy.yml` file does not define a version. therefore these collections cant be installed automatically, we need an additional step to build them.
This pull request aims to add extra steps to build and install theses kind of collection