### PR TITLE
Support all defined changelog sections

### DIFF
--- a/scripts/validate_changelog.py
+++ b/scripts/validate_changelog.py
@@ -96,9 +96,10 @@ def is_valid_changelog_format(path: str) -> bool:
     """
     try:
         config = Path("changelogs/config.yaml")
-        with open(config, "rb") as changelog_config:
-            sections = yaml.safe_load(changelog_config)["sections"]
-            changes_type = tuple(item[0] for item in sections)
+        with open(config, "rb") as config_file:
+            changelog_config = yaml.safe_load(config_file)
+            changes_type = tuple(item[0] for item in changelog_config["sections"])
+            changes_type += (changelog_config["trivial_section_name"],)
             logger.info("Found the following changelog sections: %s", changes_type)
     except (OSError, yaml.YAMLError) as exc:
         logger.info("Failed to read changelog config, using default sections instead: %s", exc)


### PR DESCRIPTION
Read the antsibull-changelog config file to look for the actual sections in use by the collection rather than relying on a fixed list. Fallback to that list if reading fails.