### PR TITLE
Chore: Repository maintanence

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,60 @@
+[flake8]
+
+builtins = _
+
+# Print the total number of errors:
+count = true
+
+# Don't even try to analyze these:
+# Feel free to add as needed, flake8 has no automatic way
+# to leverage the gitignore file
+extend-exclude =
+  # GitHub configs
+  .github,
+  # Cache files of MyPy
+  .mypy_cache,
+  # Cache files of pytest
+  .pytest_cache,
+  # Occasional virtualenv dir
+  .venv
+  # VS Code
+  .vscode,
+  # Adjacent venv
+  venv
+
+# IMPORTANT: avoid using ignore option, always use extend-ignore instead
+# Completely and unconditionally ignore the following errors:
+extend-ignore =
+  # Safeguard neutering of flake8-quotes : https://github.com/zheller/flake8-quotes/issues/105
+  Q,
+  # annoy black by allowing white space before : https://github.com/psf/black/issues/315
+  E203,
+  # duplicate of pylint W0611 (unused-import)  
+  F401,
+  # duplicate of pylint E0602 (undefined-variable)
+  F821,
+  # duplicate of pylint W0612 (unused-variable)
+  F841,
+
+# Resonable compromise:
+max-line-length = 100
+
+# Allow certain violations in certain files:
+# Please keep both sections of this list sorted, as it will be easier for others to find and add entries in the future
+per-file-ignores =
+  # The following ignores have been researched and should be considered permanent
+  # each should be preceeded with an explanation of each of the error codes
+  # If other ignores are added for a specific file in the section following this,
+  # these will need to be added to that line as well.
+
+  # EX000: Example don't do this
+  # scripts/example.py EX000
+
+  # The following were present during the initial implementation.
+  # They are expected to be fixed and unignored over time.
+
+  # EX000: Example don't do this
+  # scripts/example.py EX000
+
+# Count the number of occurrences of each error/warning code and print a report:
+statistics = true

--- a/.flake8
+++ b/.flake8
@@ -29,7 +29,7 @@ extend-ignore =
   Q,
   # annoy black by allowing white space before : https://github.com/psf/black/issues/315
   E203,
-  # duplicate of pylint W0611 (unused-import)  
+  # duplicate of pylint W0611 (unused-import)
   F401,
   # duplicate of pylint E0602 (undefined-variable)
   F821,

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,160 @@
-__pycache__
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/#use-with-ide
+.pdm.toml
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,14 +1,14 @@
 {
-    "python.formatting.provider": "black",
-    "editor.formatOnSave": true,
-    "python.linting.pylintEnabled": true,
-    "python.linting.flake8Enabled": true,
-    "python.linting.mypyEnabled": true,
-    "isort.check": true,
-    "[python]": {
-        "editor.codeActionsOnSave": {
-            "source.organizeImports": true
-        }
-    },
-    "prettier.enable": true
+  "python.formatting.provider": "black",
+  "editor.formatOnSave": true,
+  "python.linting.pylintEnabled": true,
+  "python.linting.flake8Enabled": true,
+  "python.linting.mypyEnabled": true,
+  "isort.check": true,
+  "[python]": {
+    "editor.codeActionsOnSave": {
+      "source.organizeImports": true
+    }
+  },
+  "prettier.enable": true
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,14 @@
+{
+    "python.formatting.provider": "black",
+    "editor.formatOnSave": true,
+    "python.linting.pylintEnabled": true,
+    "python.linting.flake8Enabled": true,
+    "python.linting.mypyEnabled": true,
+    "isort.check": true,
+    "[python]": {
+        "editor.codeActionsOnSave": {
+            "source.organizeImports": true
+        }
+    },
+    "prettier.enable": true
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,9 @@ profile = "black" # Avoid conflict with black
 [tool.pylint.format]
 max-line-length = 100
 
+[tool.pylint.master]
+no-docstring-rgx = "__.*__"
+
 [tool.pylint.messages_control]
 disable = ["fixme"]
 enable = [

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,0 @@
-[flake8]
-max-line-length = 160
-ignore = D103,D100
-exclude =


### PR DESCRIPTION
- Move the flake8 config into the flake8 file, since the setup.fg file is mostly legacy given PEP621
- Update the flake8 to a documented baseline configuration
- Update the .gitignore from https://raw.githubusercontent.com/github/gitignore/main/Python.gitignore
- Add a vscode settings file as a convenience reflecting the tools in use here
- Configure pylint to require docstrings for private functions