### PR TITLE
Allow continue-on-error to be toggled directly

### DIFF
--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -87,10 +87,13 @@ on:
               "ansible-version": "stable-2.9",
               "python-version": "3.6"
             },
-            {
-              "ansible-version": "devel",
-              "unstable": true,
-            },
+          ]
+        required: false
+        type: string
+      unstable:
+        default: >-
+          [
+            "devel",
           ]
         required: false
         type: string
@@ -119,11 +122,10 @@ jobs:
           - "3.9"
           - "3.10"
           - "3.11"
-        unstable: [false]
         exclude: ${{ fromJSON(inputs.matrix_exclude) }}
         include: ${{ fromJSON(inputs.matrix_include) }}
     runs-on: ${{ matrix.os }}
-    continue-on-error: ${{ matrix.unstable }}
+    continue-on-error: ${{ contains(fromJSON(inputs.unstable), matrix.ansible-version) }}
 
     name: "py${{ matrix.python-version }} / ${{ matrix.os }} / ${{ matrix.ansible-version }}"
     steps:

--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -87,6 +87,10 @@ on:
               "ansible-version": "stable-2.9",
               "python-version": "3.6"
             },
+            {
+              "ansible-version": "devel",
+              "unstable": true,
+            },
           ]
         required: false
         type: string
@@ -115,10 +119,11 @@ jobs:
           - "3.9"
           - "3.10"
           - "3.11"
+        unstable: [false]
         exclude: ${{ fromJSON(inputs.matrix_exclude) }}
         include: ${{ fromJSON(inputs.matrix_include) }}
     runs-on: ${{ matrix.os }}
-    continue-on-error: ${{ matrix.ansible-version == 'devel' }}
+    continue-on-error: ${{ matrix.unstable }}
 
     name: "py${{ matrix.python-version }} / ${{ matrix.os }} / ${{ matrix.ansible-version }}"
     steps:


### PR DESCRIPTION
We currently `continue-on-fail` for `devel`, but this could use more fine-grained control