### PR TITLE
Support pre-install for unit, sanity and integration tests

### DIFF
--- a/.github/actions/build_install_collection/action.yml
+++ b/.github/actions/build_install_collection/action.yml
@@ -79,7 +79,7 @@ runs:
       working-directory: ${{ inputs.source_path }}
 
     - name: Install collection and dependencies
-      run: ansible-galaxy collection install ./${{ steps.identify.outputs.tar_file || inputs.tar_file }} -p /home/runner/collections
+      run: ansible-galaxy collection install ./${{ steps.identify.outputs.tar_file || inputs.tar_file }} --pre -p /home/runner/collections
       shell: bash
       working-directory: ${{ inputs.source_path }}
 

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -2,6 +2,10 @@ name: Integration tests
 on:
   workflow_call:
     inputs:
+      collection_pre_install:
+        required: false
+        type: string
+        default: ""
       cml_lab:
         default: tests/integration/labs/single.yaml
         required: false
@@ -71,6 +75,10 @@ jobs:
 
       - name: Install ansible-core (${{ matrix.ansible-version }})
         run: python3 -m pip install https://github.com/ansible/ansible/archive/${{ matrix.ansible-version }}.tar.gz --disable-pip-version-check
+
+      - name: Pre install collections dependencies first so the collection install does not
+        run: ansible-galaxy collection install --pre ${{ inputs.collection_pre_install }} -p /home/runner/collections
+        if: inputs.collection_pre_install != ''
 
       - name: Read collection metadata from galaxy.yml
         id: identify

--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -2,6 +2,10 @@ name: Sanity tests
 on:
   workflow_call:
     inputs:
+      collection_pre_install:
+        required: false
+        type: string
+        default: ""
       matrix_exclude:
         # https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html#ansible-core-support-matrix
         # 2.9 supports Python 3.5-3.8
@@ -143,6 +147,10 @@ jobs:
 
       - name: Install ansible-core (${{ matrix.ansible-version }})
         run: python3 -m pip install https://github.com/ansible/ansible/archive/${{ matrix.ansible-version }}.tar.gz --disable-pip-version-check
+
+      - name: Pre install collections dependencies first so the collection install does not
+        run: ansible-galaxy collection install --pre ${{ inputs.collection_pre_install }} -p /home/runner/collections/
+        if: inputs.collection_pre_install != ''
 
       - name: Read collection metadata from galaxy.yml
         id: identify

--- a/.github/workflows/unit_galaxy.yml
+++ b/.github/workflows/unit_galaxy.yml
@@ -2,6 +2,10 @@ name: Unit tests, dependencies from galaxy
 on:
   workflow_call:
     inputs:
+      collection_pre_install:
+        required: false
+        type: string
+        default: ""
       matrix_exclude:
         # https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html#ansible-core-support-matrix
         # 2.9 supports Python 3.5-3.8
@@ -136,6 +140,10 @@ jobs:
 
       - name: Install ansible-core (${{ matrix.ansible-version }})
         run: python3 -m pip install https://github.com/ansible/ansible/archive/${{ matrix.ansible-version }}.tar.gz --disable-pip-version-check
+
+      - name: Pre install collections dependencies first so the collection install does not
+        run: ansible-galaxy collection install --pre ${{ inputs.collection_pre_install }} -p /home/runner/collections
+        if: inputs.collection_pre_install != ''
 
       - name: Read collection metadata from galaxy.yml
         id: identify

--- a/.github/workflows/unit_source.yml
+++ b/.github/workflows/unit_source.yml
@@ -3,8 +3,9 @@ on:
   workflow_call:
     inputs:
       collection_pre_install:
-        required: true
+        required: false
         type: string
+        default: ""
       matrix_exclude:
         # https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html#ansible-core-support-matrix
         # 2.12 supports Python 3.8-3.10
@@ -86,15 +87,15 @@ jobs:
       - name: Install ansible-core (${{ matrix.ansible-version }})
         run: python3 -m pip install https://github.com/ansible/ansible/archive/${{ matrix.ansible-version }}.tar.gz --disable-pip-version-check
 
+      - name: Pre install collections dependencies first so the collection install does not
+        run: ansible-galaxy collection install --pre ${{ inputs.collection_pre_install }} -p /home/runner/collections
+        if: inputs.collection_pre_install != ''
+
       - name: Read collection metadata from galaxy.yml
         id: identify
         uses: ansible-network/github_actions/.github/actions/identify_collection@main
         with:
           source_path: ${{ env.source_directory }}
-
-      - name: Pre install collections dependencies first so the collection install does not
-        run: ansible-galaxy collection install --pre ${{ inputs.collection_pre_install }} -p /home/runner/collections
-        if: inputs.collection_pre_install != ''
 
       - name: Build and install the collection
         uses: ansible-network/github_actions/.github/actions/build_install_collection@main


### PR DESCRIPTION
community.aws depends on amazon.aws.

When adding new code to amazon.aws for community.aws to consume we need the ability to pull in amazon.aws prior to it being released to galaxy.

Also allows the use of pre-releases, we are specifically testing code **before** it's been released to galaxy, so a prerelease prefix is perfectly reasonable.