### PR TITLE
Use --pre only with supported Ansible versions

### DIFF
--- a/.github/actions/build_install_collection/action.yml
+++ b/.github/actions/build_install_collection/action.yml
@@ -18,7 +18,11 @@ inputs:
       The collection tarball when built
       If not set, this will be determined by the action
     default: ""
-
+  ansible_version:
+    description: |
+      Ansible Core version from the workflow.
+    required: false
+    default: ""
 outputs:
   collection_path:
     description: The final collection path
@@ -62,6 +66,7 @@ runs:
 
     - name: Install collection python requirements
       if: ${{ inputs.install_python_dependencies == 'true' }}
+
       run: python3 -m pip install -r requirements.txt -r test-requirements.txt
       shell: bash
       working-directory: ${{ inputs.source_path }}
@@ -78,10 +83,17 @@ runs:
       shell: bash
       working-directory: ${{ inputs.source_path }}
 
-    - name: Install collection and dependencies
+    - name: Install collection and dependencies (with --pre flag)
       run: ansible-galaxy collection install ./${{ steps.identify.outputs.tar_file || inputs.tar_file }} --pre -p /home/runner/collections
       shell: bash
       working-directory: ${{ inputs.source_path }}
+      if: ${{ inputs.ansible_version != "stable-2.9" }}
+
+    - name: Install collection and dependencies (without --pre flag)
+      run: ansible-galaxy collection install ./${{ steps.identify.outputs.tar_file || inputs.tar_file }} -p /home/runner/collections
+      shell: bash
+      working-directory: ${{ inputs.source_path }}
+      if: ${{ inputs.ansible_version == "stable-2.9" }}
 
     - name: Copy the galaxy.yml from source to destination, needed for pytest-ansible-units
       run: cp galaxy.yml ${{ steps.identify.outputs.collection_path || inputs.collection_path }}/galaxy.yml

--- a/.github/actions/build_install_collection/action.yml
+++ b/.github/actions/build_install_collection/action.yml
@@ -87,13 +87,13 @@ runs:
       run: ansible-galaxy collection install ./${{ steps.identify.outputs.tar_file || inputs.tar_file }} --pre -p /home/runner/collections
       shell: bash
       working-directory: ${{ inputs.source_path }}
-      if: ${{ inputs.ansible_version != "stable-2.9" }}
+      if: ${{ inputs.ansible_version != 'stable-2.9' }}
 
     - name: Install collection and dependencies (without --pre flag)
       run: ansible-galaxy collection install ./${{ steps.identify.outputs.tar_file || inputs.tar_file }} -p /home/runner/collections
       shell: bash
       working-directory: ${{ inputs.source_path }}
-      if: ${{ inputs.ansible_version == "stable-2.9" }}
+      if: ${{ inputs.ansible_version == 'stable-2.9' }}
 
     - name: Copy the galaxy.yml from source to destination, needed for pytest-ansible-units
       run: cp galaxy.yml ${{ steps.identify.outputs.collection_path || inputs.collection_path }}/galaxy.yml

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -117,6 +117,7 @@ jobs:
           source_path: ${{ env.source_directory }}
           collection_path: ${{ steps.identify.outputs.collection_path }}
           tar_file: ${{ steps.identify.outputs.tar_file }}
+          ansible_version: ${{ matrix.ansible-version }}
 
       - name: Print the ansible version
         run: ansible --version

--- a/.github/workflows/integration_simple.yml
+++ b/.github/workflows/integration_simple.yml
@@ -123,6 +123,7 @@ jobs:
           source_path: ${{ env.source_directory }}
           collection_path: ${{ steps.identify.outputs.collection_path }}
           tar_file: ${{ steps.identify.outputs.tar_file }}
+          ansible_version: ${{ matrix.ansible-version }}
 
       - name: Print the ansible version
         run: ansible --version

--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -150,7 +150,7 @@ jobs:
 
       - name: Pre install collections dependencies first so the collection install does not
         run: ansible-galaxy collection install --pre ${{ inputs.collection_pre_install }} -p /home/runner/collections/
-        if: inputs.collection_pre_install != ''
+        if: ${{ inputs.collection_pre_install != '' && matrix.ansible-version != 'stable-2.9' }}
 
       - name: Read collection metadata from galaxy.yml
         id: identify
@@ -165,6 +165,7 @@ jobs:
           source_path: ${{ env.source_directory }}
           collection_path: ${{ steps.identify.outputs.collection_path }}
           tar_file: ${{ steps.identify.outputs.tar_file }}
+          ansible_version: ${{ matrix.ansible-version }}
 
       - name: Print the ansible version
         run: ansible --version

--- a/.github/workflows/unit_galaxy.yml
+++ b/.github/workflows/unit_galaxy.yml
@@ -143,7 +143,7 @@ jobs:
 
       - name: Pre install collections dependencies first so the collection install does not
         run: ansible-galaxy collection install --pre ${{ inputs.collection_pre_install }} -p /home/runner/collections
-        if: inputs.collection_pre_install != ''
+        if: ${{ inputs.collection_pre_install != '' && matrix.ansible-version != 'stable-2.9' }}
 
       - name: Read collection metadata from galaxy.yml
         id: identify
@@ -158,6 +158,7 @@ jobs:
           source_path: ${{ env.source_directory }}
           collection_path: ${{ steps.identify.outputs.collection_path }}
           tar_file: ${{ steps.identify.outputs.tar_file }}
+          ansible_version: ${{ matrix.ansible-version }}
 
       - name: Print the ansible version
         run: ansible --version

--- a/.github/workflows/unit_source.yml
+++ b/.github/workflows/unit_source.yml
@@ -104,6 +104,7 @@ jobs:
           source_path: ${{ env.source_directory }}
           collection_path: ${{ steps.identify.outputs.collection_path }}
           tar_file: ${{ steps.identify.outputs.tar_file }}
+          ansible_version: ${{ matrix.ansible-version }}
 
       - name: Print the ansible version
         run: ansible --version


### PR DESCRIPTION
- The changes in https://github.com/ansible-network/github_actions/pull/102/ are causing GHA workflows for networking collections to fail, since we still test with Ansible 2.9.
- Fixes #104 