### PR TITLE
ansible_test_splitter - extend feature for roles

### DIFF
--- a/.github/actions/ansible_test_splitter/REAME.md
+++ b/.github/actions/ansible_test_splitter/REAME.md
@@ -1,0 +1,90 @@
+# ansible_test_splitter
+
+This action identifies the targets impacted by the changes on a pull request and split them into a number of jobs defined by the user.
+
+## Usage
+
+<!-- start usage -->
+
+```yaml
+- uses: ansible-network/github_actions/.github/actions/ansible_test_splitter@main
+  with:
+    # Path to a list of collections
+    collections_to_test: |
+      path_to_collection_1
+      path_to_collection_2
+      (...)
+      path_to_collection_n
+
+    # The total number of jobs to share
+    total_jobs: 5
+```
+
+The action output is a variable `test_targets` containing a list of chunk for each collection with the targets for each chunk.
+e.g: `community.aws-1:dynamodb_table;community.aws-2:elb_target;community.aws-3:msk_cluster-auth;community.aws-4:secretsmanager_secret;community.aws-5:redshift,ec2_transit_gateway_vpc_attachment`
+
+<!-- end usage -->
+
+## Relationship between plugins/roles and targets
+
+This action reads elements to test from `plugins` and `roles` directories and corresponding tests from `tests/integration/targets` directory. Here after more details on the relationship between plugins/roles and integration tests targets:
+
+- `modules`, the test target should have the same name as the module or defines the module name into the `aliases` file
+
+_Example_:
+
+```
+    |___plugins/modules/my_module.py
+    |___tests
+        |___integration
+            |___targets
+                |___my_module
+                |___another_test
+                    |___aliases (contains this line my_module)
+```
+
+For any change on `plugins/modules/my_module.py`, this action will produce `my_module` and `another_test` as impacted targets.
+
+- `roles`, the test target should defines the role name with the prefix `role` into the `aliases` file.
+
+_Example_:
+
+```
+    |___roles/some_role
+    |___tests
+        |___integration
+            |___targets
+                |___test_of_some_role
+                    |___aliases (contains this line role/some_role)
+```
+
+For any change on `roles/some_role`, this action will produce `test_of_some_role` as impacted target.
+
+- For any other plugin (inventory, connection, module_utils, plugin_utils, lookup), the test target should have the same name as the plugin or defines the plugin name prefixed by the plugin type and underscore (e.g: **inventory_myinventory**) into the `aliases` file.
+
+_Example_:
+
+```
+    |___plugins/lookup/random.py
+    |___tests
+        |___integration
+            |___targets
+                |___random
+                |___test_random
+                    |___aliases (contains this line lookup_random)
+```
+
+For any change on `plugins/lookup/random.py`, this action will produce `test_random` and `test_random` as impacted targets.
+
+## Debugging
+
+- Set the label `test-all-the-targets` on the pull request to run the full test suite instead of the impacted changes.
+- Use `TargetsToTest=collection1:target01,target02;collection2:target03,target4` in the pull request description to run a specific list of targets.
+  _Example_: You need to test the following targets for a pull request
+
+```yaml
+- collection1: some_test_1 some_test_2
+- collection2: another_test
+```
+
+The pull request should contain the following line `TargetsToTest=collection1:some_test_1,some_test_2;collection2:another_test`.

--- a/.github/actions/ansible_test_splitter/REAME.md
+++ b/.github/actions/ansible_test_splitter/REAME.md
@@ -69,12 +69,12 @@ _Example_:
     |___tests
         |___integration
             |___targets
-                |___random
+                |___lookup_random
                 |___test_random
                     |___aliases (contains this line lookup_random)
 ```
 
-For any change on `plugins/lookup/random.py`, this action will produce `test_random` and `test_random` as impacted targets.
+For any change on `plugins/lookup/random.py`, this action will produce `lookup_random` and `test_random` as impacted targets.
 
 ## Debugging
 

--- a/.github/actions/ansible_test_splitter/action.yml
+++ b/.github/actions/ansible_test_splitter/action.yml
@@ -12,10 +12,6 @@ inputs:
     description: The total number of jobs to share targets on
     required: false
     default: "3"
-  base_ref:
-    description: The git diff base ref
-    required: false
-    default: "3"
 outputs:
   test_targets:
     description: The list of targets to test
@@ -46,5 +42,5 @@ runs:
         COLLECTIONS_TO_TEST: "${{ inputs.collections_to_test }}"
         TOTAL_JOBS: "${{ inputs.total_jobs }}"
         PULL_REQUEST_BODY: "${{ github.event.pull_request.body }}"
-        PULL_REQUEST_BASE_REF: "${{ github.event.pull_request.base.ref || inputs.base_ref }}"
+        PULL_REQUEST_BASE_REF: "${{ github.event.pull_request.base.ref }}"
       shell: bash

--- a/.github/actions/ansible_test_splitter/action.yml
+++ b/.github/actions/ansible_test_splitter/action.yml
@@ -12,6 +12,10 @@ inputs:
     description: The total number of jobs to share targets on
     required: false
     default: "3"
+  base_ref:
+    description: The git diff base ref
+    required: false
+    default: "3"
 outputs:
   test_targets:
     description: The list of targets to test
@@ -42,5 +46,5 @@ runs:
         COLLECTIONS_TO_TEST: "${{ inputs.collections_to_test }}"
         TOTAL_JOBS: "${{ inputs.total_jobs }}"
         PULL_REQUEST_BODY: "${{ github.event.pull_request.body }}"
-        PULL_REQUEST_BASE_REF: "${{ github.event.pull_request.base.ref }}"
+        PULL_REQUEST_BASE_REF: "${{ github.event.pull_request.base.ref || inputs.base_ref }}"
       shell: bash

--- a/.github/actions/ansible_test_splitter/list_changed_common.py
+++ b/.github/actions/ansible_test_splitter/list_changed_common.py
@@ -229,6 +229,13 @@ class WhatHaveChanged:
         """
         yield from self._path_matches("plugins/modules/")
 
+    def roles(self) -> Generator[PosixPath, None, None]:
+        """List the roles impacted by the change.
+
+        :yields: path to a role change
+        """
+        yield from self._path_matches("roles/")
+
     def _util_matches(
         self, base_path: str, import_path: str
     ) -> Generator[tuple[PosixPath, str], None, None]:

--- a/.github/actions/ansible_test_splitter/list_changed_common.py
+++ b/.github/actions/ansible_test_splitter/list_changed_common.py
@@ -173,9 +173,8 @@ class WhatHaveChanged:
         :returns: a list of pathlib.PosixPath
         """
         if not self.files:
-            stdout = run_command(
-                command=f"git diff origin/{self.base_ref} --name-only", chdir=self.collection_path
-            )
+            changed_files_cmd = f"git diff origin/{self.base_ref} --name-only"
+            stdout = run_command(command=changed_files_cmd, chdir=self.collection_path)
             self.files = [PosixPath(p) for p in stdout.split("\n") if p]
         return self.files
 

--- a/.github/actions/ansible_test_splitter/list_changed_common.py
+++ b/.github/actions/ansible_test_splitter/list_changed_common.py
@@ -229,12 +229,14 @@ class WhatHaveChanged:
         """
         yield from self._path_matches("plugins/modules/")
 
-    def roles(self) -> Generator[PosixPath, None, None]:
+    def roles(self) -> Generator[str, None, None]:
         """List the roles impacted by the change.
 
         :yields: path to a role change
         """
-        yield from self._path_matches("roles/")
+        for changed_file in self.changed_files():
+            if str(changed_file).startswith("roles/"):
+                yield str(changed_file).split("/", maxsplit=2)[1]
 
     def _util_matches(
         self, base_path: str, import_path: str

--- a/.github/actions/ansible_test_splitter/list_changed_common.py
+++ b/.github/actions/ansible_test_splitter/list_changed_common.py
@@ -174,6 +174,7 @@ class WhatHaveChanged:
         """
         if not self.files:
             changed_files_cmd = f"git diff origin/{self.base_ref} --name-only"
+            print(f"Command for changed files => {changed_files_cmd}")
             stdout = run_command(command=changed_files_cmd, chdir=self.collection_path)
             self.files = [PosixPath(p) for p in stdout.split("\n") if p]
         return self.files

--- a/.github/actions/ansible_test_splitter/list_changed_targets.py
+++ b/.github/actions/ansible_test_splitter/list_changed_targets.py
@@ -88,6 +88,7 @@ class ListChangedTargets:
                 collection.add_target_to_plan(plugin_file_name)
 
         for whc in [WhatHaveChanged(path, self.base_ref) for path in self.collections_to_test]:
+            print(f"changes file for collection [{whc.collection_name}] => {whc.changed_files()}")
             listed_changes[whc.collection_name] = {
                 "modules": [],
                 "inventory": [],

--- a/.github/actions/ansible_test_splitter/list_changed_targets.py
+++ b/.github/actions/ansible_test_splitter/list_changed_targets.py
@@ -79,7 +79,7 @@ class ListChangedTargets:
                 plugin_file_name = file_name
             elif plugin_type == "roles":
                 file_name = str(ref_path)
-                plugin_file_name = f"role/{file_name}"
+                plugin_file_name = f"role/{ref_path}"
             else:
                 file_name = PosixPath(ref_path).stem
                 plugin_file_name = f"{plugin_type}_{PosixPath(ref_path).stem}"

--- a/.github/actions/ansible_test_splitter/list_changed_targets.py
+++ b/.github/actions/ansible_test_splitter/list_changed_targets.py
@@ -77,6 +77,9 @@ class ListChangedTargets:
             elif plugin_type == "modules":
                 file_name = PosixPath(ref_path).stem
                 plugin_file_name = file_name
+            elif plugin_type == "roles":
+                file_name = str(ref_path)
+                plugin_file_name = f"role/{file_name}"
             else:
                 file_name = PosixPath(ref_path).stem
                 plugin_file_name = f"{plugin_type}_{PosixPath(ref_path).stem}"
@@ -93,6 +96,7 @@ class ListChangedTargets:
                 "plugin_utils": [],
                 "lookup": [],
                 "targets": [],
+                "roles": [],
             }
             for path in whc.modules():
                 _add_changed_target(whc.collection_name, path, "modules")
@@ -112,6 +116,8 @@ class ListChangedTargets:
                 _add_changed_target(whc.collection_name, path, "lookup")
             for target in whc.targets():
                 _add_changed_target(whc.collection_name, target, "targets")
+            for role in whc.roles():
+                _add_changed_target(whc.collection_name, role, "roles")
 
         print("----------- Listed Changes -----------\n", json.dumps(listed_changes, indent=2))
         return {x: make_unique(y["targets"]) for x, y in listed_changes.items()}

--- a/.github/actions/ansible_test_splitter/list_changed_targets.py
+++ b/.github/actions/ansible_test_splitter/list_changed_targets.py
@@ -88,7 +88,7 @@ class ListChangedTargets:
                 collection.add_target_to_plan(plugin_file_name)
 
         for whc in [WhatHaveChanged(path, self.base_ref) for path in self.collections_to_test]:
-            print(f"changes file for collection [{whc.collection_name}] => {whc.changed_files()}")
+            print(f"changed file for collection [{whc.collection_name}] => {whc.changed_files()}")
             listed_changes[whc.collection_name] = {
                 "modules": [],
                 "inventory": [],


### PR DESCRIPTION
`ansible_test_splitter` Github action should support git change for integration test targets as roles
The integration test target should define the value `role/role_to_test` into the `aliases` file
