### PR TITLE
safe-to-test worflow: some updates

### DIFF
--- a/.github/workflows/safe-to-test.yml
+++ b/.github/workflows/safe-to-test.yml
@@ -19,7 +19,8 @@ jobs:
         run: |
           user_role=$(gh api --jq .permission -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" $GH_API_URL)
           roles=("write maintain admin")
-          [[ "${roles[*]} " =~ "${user_role} " ]] && echo "collaborator=true" || echo "collaborator=false" >> $GITHUB_OUTPUT
+          [[ "${roles[*]} " =~ "${user_role} " ]] && collaborator=true || collaborator=false
+          echo "collaborator=${collaborator}" >> $GITHUB_OUTPUT
         env:
           GH_API_URL: "/repos/${{ github.repository }}/collaborators/${{ github.event.pull_request.user.login }}/permission"
 
@@ -41,10 +42,10 @@ jobs:
       - name: Remove the 'safe to test', not a collaborator, PR was updated or not just added
         run: gh pr edit ${{ github.event.number }} --remove-label "safe to test"
         if: >-
-          ${{ steps.authorization.outputs.collaborator == 'false' }} &&
-          ${{ steps.read-label.outputs.safe_label != '' }} &&
-          ${{ github.event.label.name != 'safe to test' }} &&
-          ${{ github.event.action == 'synchronize' || github.event.action == 'reopened' }}
+          steps.authorization.outputs.collaborator == 'false' &&
+          steps.read-label.outputs.safe_label != '' &&
+          github.event.label.name != 'safe to test' &&
+          (github.event.action == 'synchronize' || github.event.action == 'reopened')
 
       - name: Fail if not now labeled
         run: >-

--- a/.github/workflows/safe-to-test.yml
+++ b/.github/workflows/safe-to-test.yml
@@ -10,41 +10,51 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GITHUB_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN  }}
+      GH_REPOSITORY_ROLES: >-
+        [
+          "write",
+          "maintain",
+          "admin"
+        ]
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v3
 
-      - name: Check if the PR author is a collaborator
+      - name: Get user Role on repository
         id: authorization
-        run: 'gh api -H "Accept: application/vnd.github.v3+json" $API_URL'
-        continue-on-error: true
+        run: |
+          user_role=$(gh api --jq .permission -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" $GH_API_URL)
+          roles=("write maintain admin")
+          [[ "${roles[*]} " =~ "${user_role} " ]] && echo "collaborator=true" || echo "collaborator=false" >> $GITHUB_OUTPUT
         env:
-          API_URL: /repos/${{ github.repository }}/collaborators/${{ github.event.pull_request.user.login }}
-          GITHUB_TOKEN: ${{ env.GITHUB_TOKEN }}
-        if: github.event.label.name != 'safe to test'
+          GH_API_URL: "/repos/${{ github.repository }}/collaborators/${{ github.event.pull_request.user.login }}/permission"
 
-      - name: If collaborator, add the label
-        run: gh pr edit $PR_NUMBER --add-label "safe to test"
+      # Add 'safe to test' label for collaborators
+      - name: Add safe label for User with required roles
+        run: gh pr edit ${{ github.event.number }} --add-label "safe to test"
+        if: ${{ steps.authorization.outputs.collaborator == 'true' }}
+
+      # Remove 'safe to test' for non collaborators
+      - name: Get pull request labels
+        id: read-label
+        run: |
+          SAFE_LABEL=$(gh api --jq '.[] | select(.name == "safe to test") | .name' -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" $GH_API_URL)
+          echo "safe_label=$SAFE_LABEL" >> $GITHUB_OUTPUT
         env:
-          GITHUB_TOKEN: ${{ env.GITHUB_TOKEN }}
-          PR_NUMBER: ${{ github.event.number }}
-        if: steps.authorization.outcome == 'success'
+          GH_API_URL: /repos/${{ github.repository }}/issues/${{ github.event.number }}/labels
+        if: ${{ steps.authorization.outputs.collaborator == 'false' }}
 
       - name: Remove the 'safe to test', not a collaborator, PR was updated or not just added
-        id: removed
-        run: gh pr edit $PR_NUMBER --remove-label "safe to test"
-        env:
-          GITHUB_TOKEN: ${{ env.GITHUB_TOKEN }}
-          PR_NUMBER: ${{ github.event.number }}
+        run: gh pr edit ${{ github.event.number }} --remove-label "safe to test"
         if: >-
-          steps.authorization.outcome != 'success' &&
-          github.event.label.name != 'safe to test' &&
-          ( github.event.action == 'synchronize' || github.event.action == 'reopened' )
+          ${{ steps.authorization.outputs.collaborator == 'false' }} &&
+          ${{ steps.read-label.outputs.safe_label != '' }} &&
+          ${{ github.event.label.name != 'safe to test' }} &&
+          ${{ github.event.action == 'synchronize' || github.event.action == 'reopened' }}
 
       - name: Fail if not now labeled
         run: >-
           gh api -H "Accept: application/vnd.github.v3+json" $API_URL
           --jq .labels | grep 'safe to test'
         env:
-          GITHUB_TOKEN: ${{ env.GITHUB_TOKEN }}
           API_URL: /repos/${{ github.repository }}/issues/${{ github.event.number }}

--- a/.github/workflows/safe-to-test.yml
+++ b/.github/workflows/safe-to-test.yml
@@ -10,17 +10,11 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GITHUB_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN  }}
-      GH_REPOSITORY_ROLES: >-
-        [
-          "write",
-          "maintain",
-          "admin"
-        ]
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v3
 
-      - name: Get user Role on repository
+      - name: Check if the PR author is a collaborator
         id: authorization
         run: |
           user_role=$(gh api --jq .permission -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" $GH_API_URL)


### PR DESCRIPTION
This pull request fix some issue with the `safe-to-test` workflow
- Retrieve the user role instead of a list of repository collaborators as sometimes collaborators can be hidden behind a team group, in that case, GH API does not return the login as part of the collaborators list
- check if the label exists on the pull request before trying to delete it, GH API fails when trying to delete a label not part of the pull request.