### PR TITLE
Drop 3.9 support for Ansible 2.16

### DIFF
--- a/.github/workflows/integration_simple.yml
+++ b/.github/workflows/integration_simple.yml
@@ -13,6 +13,7 @@ on:
         # 2.13 supports Python 3.8-3.10
         # 2.14 supports Python 3.9-3.11
         # 2.15 supports Python 3.9-3.11
+        # 2.16 supports Python 3.10-3.11
         # https://docs.ansible.com/ansible/devel/roadmap/ROADMAP_2_16.html
         # milestone is 2.15 until 2023-05-01
         # devel is 2.16 until 2023-09-18
@@ -53,6 +54,10 @@ on:
             {
               "ansible-version": "devel",
               "python-version": "3.8"
+            },
+            {
+              "ansible-version": "devel",
+              "python-version": "3.9"
             }
           ]
         required: false

--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -13,6 +13,7 @@ on:
         # 2.13 supports Python 3.8-3.10
         # 2.14 supports Python 3.9-3.11
         # 2.15 supports Python 3.9-3.11
+        # 2.16 supports Python 3.10-3.11
         # https://docs.ansible.com/ansible/devel/roadmap/ROADMAP_2_16.html
         # milestone is 2.15 until 2023-05-01
         # devel is 2.16 until 2023-09-18
@@ -77,6 +78,10 @@ on:
             {
               "ansible-version": "devel",
               "python-version": "3.8"
+            },
+            {
+              "ansible-version": "devel",
+              "python-version": "3.9"
             }
           ]
         required: false

--- a/.github/workflows/unit_galaxy.yml
+++ b/.github/workflows/unit_galaxy.yml
@@ -13,6 +13,7 @@ on:
         # 2.13 supports Python 3.8-3.10
         # 2.14 supports Python 3.9-3.11
         # 2.15 supports Python 3.9-3.11
+        # 2.16 supports Python 3.10-3.11
         # https://docs.ansible.com/ansible/devel/roadmap/ROADMAP_2_16.html
         # milestone is 2.15 until 2023-05-01
         # devel is 2.16 until 2023-09-18
@@ -77,6 +78,10 @@ on:
             {
               "ansible-version": "devel",
               "python-version": "3.8"
+            },
+            {
+              "ansible-version": "devel",
+              "python-version": "3.9"
             }
           ]
         required: false

--- a/.github/workflows/unit_source.yml
+++ b/.github/workflows/unit_source.yml
@@ -12,6 +12,7 @@ on:
         # 2.13 supports Python 3.8-3.10
         # 2.14 supports Python 3.9-3.11
         # 2.15 supports Python 3.9-3.11
+        # 2.16 supports Python 3.10-3.11
         # https://docs.ansible.com/ansible/devel/roadmap/ROADMAP_2_16.html
         # milestone is 2.15 until 2023-05-01
         # devel is 2.16 until 2023-09-18
@@ -40,6 +41,10 @@ on:
             {
               "ansible-version": "devel",
               "python-version": "3.8"
+            },
+            {
+              "ansible-version": "devel",
+              "python-version": "3.9"
             }
           ]
         required: false


### PR DESCRIPTION
3.9 support was just dropped from devel, so drop it from our matrix.