### PR TITLE
Stop testing milestone on Python 3.9

### DIFF
--- a/.github/workflows/integration_simple.yml
+++ b/.github/workflows/integration_simple.yml
@@ -15,7 +15,7 @@ on:
         # 2.15 supports Python 3.9-3.11
         # 2.16 supports Python 3.10-3.11
         # https://docs.ansible.com/ansible/devel/roadmap/ROADMAP_2_16.html
-        # milestone is 2.15 until 2023-05-01
+        # milestone is 2.16 until after 2.16 branches from devel
         # devel is 2.16 until 2023-09-18
         default: >-
           [
@@ -50,6 +50,10 @@ on:
             {
               "ansible-version": "milestone",
               "python-version": "3.8"
+            },
+            {
+              "ansible-version": "milestone",
+              "python-version": "3.9"
             },
             {
               "ansible-version": "devel",

--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -15,7 +15,7 @@ on:
         # 2.15 supports Python 3.9-3.11
         # 2.16 supports Python 3.10-3.11
         # https://docs.ansible.com/ansible/devel/roadmap/ROADMAP_2_16.html
-        # milestone is 2.15 until 2023-05-01
+        # milestone is 2.16 until after 2.16 branches from devel
         # devel is 2.16 until 2023-09-18
         default: >-
           [
@@ -70,6 +70,10 @@ on:
             {
               "ansible-version": "milestone",
               "python-version": "3.8"
+            },
+            {
+              "ansible-version": "milestone",
+              "python-version": "3.9"
             },
             {
               "ansible-version": "devel",

--- a/.github/workflows/unit_galaxy.yml
+++ b/.github/workflows/unit_galaxy.yml
@@ -15,7 +15,7 @@ on:
         # 2.15 supports Python 3.9-3.11
         # 2.16 supports Python 3.10-3.11
         # https://docs.ansible.com/ansible/devel/roadmap/ROADMAP_2_16.html
-        # milestone is 2.15 until 2023-05-01
+        # milestone is 2.16 until after 2.16 branches from devel
         # devel is 2.16 until 2023-09-18
         default: >-
           [
@@ -70,6 +70,10 @@ on:
             {
               "ansible-version": "milestone",
               "python-version": "3.8"
+            },
+            {
+              "ansible-version": "milestone",
+              "python-version": "3.9"
             },
             {
               "ansible-version": "devel",

--- a/.github/workflows/unit_source.yml
+++ b/.github/workflows/unit_source.yml
@@ -14,7 +14,7 @@ on:
         # 2.15 supports Python 3.9-3.11
         # 2.16 supports Python 3.10-3.11
         # https://docs.ansible.com/ansible/devel/roadmap/ROADMAP_2_16.html
-        # milestone is 2.15 until 2023-05-01
+        # milestone is 2.16 until after 2.16 branches from devel
         # devel is 2.16 until 2023-09-18
         default: >-
           [
@@ -37,6 +37,10 @@ on:
             {
               "ansible-version": "milestone",
               "python-version": "3.8"
+            },
+            {
+              "ansible-version": "milestone",
+              "python-version": "3.9"
             },
             {
               "ansible-version": "devel",


### PR DESCRIPTION
Support for Python 3.9 has been dropped from `devel`, `milestone` will follow eventually.