### PR TITLE
Stop testing stable-2.12

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -42,7 +42,6 @@ jobs:
       matrix:
         ansible-version:
           # - stable-2.9
-          # - stable-2.12
           - stable-2.13
           # - stable-2.14
           # - stable-2.15

--- a/.github/workflows/integration_simple.yml
+++ b/.github/workflows/integration_simple.yml
@@ -9,7 +9,6 @@ on:
       matrix_exclude:
         # https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html#ansible-core-support-matrix
         # 2.9 supports Python 3.5-3.8
-        # 2.12 supports Python 3.8-3.10
         # 2.13 supports Python 3.8-3.10
         # 2.14 supports Python 3.9-3.11
         # 2.15 supports Python 3.9-3.11
@@ -29,10 +28,6 @@ on:
             },
             {
               "ansible-version": "stable-2.9",
-              "python-version": "3.11"
-            },
-            {
-              "ansible-version": "stable-2.12",
               "python-version": "3.11"
             },
             {
@@ -81,7 +76,6 @@ jobs:
       matrix:
         ansible-version:
           - stable-2.9
-          - stable-2.12
           - stable-2.13
           - stable-2.14
           - stable-2.15

--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -9,7 +9,6 @@ on:
       matrix_exclude:
         # https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html#ansible-core-support-matrix
         # 2.9 supports Python 3.5-3.8
-        # 2.12 supports Python 3.8-3.10
         # 2.13 supports Python 3.8-3.10
         # 2.14 supports Python 3.9-3.11
         # 2.15 supports Python 3.9-3.11
@@ -29,14 +28,6 @@ on:
             },
             {
               "ansible-version": "stable-2.9",
-              "python-version": "3.11"
-            },
-            {
-              "ansible-version": "stable-2.12",
-              "python-version": "3.7"
-            },
-            {
-              "ansible-version": "stable-2.12",
               "python-version": "3.11"
             },
             {
@@ -119,7 +110,6 @@ jobs:
           - ubuntu-latest
         ansible-version:
           - stable-2.9
-          - stable-2.12
           - stable-2.13
           - stable-2.14
           - stable-2.15

--- a/.github/workflows/unit_galaxy.yml
+++ b/.github/workflows/unit_galaxy.yml
@@ -9,7 +9,6 @@ on:
       matrix_exclude:
         # https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html#ansible-core-support-matrix
         # 2.9 supports Python 3.5-3.8
-        # 2.12 supports Python 3.8-3.10
         # 2.13 supports Python 3.8-3.10
         # 2.14 supports Python 3.9-3.11
         # 2.15 supports Python 3.9-3.11
@@ -29,14 +28,6 @@ on:
             },
             {
               "ansible-version": "stable-2.9",
-              "python-version": "3.11"
-            },
-            {
-              "ansible-version": "stable-2.12",
-              "python-version": "3.7"
-            },
-            {
-              "ansible-version": "stable-2.12",
               "python-version": "3.11"
             },
             {
@@ -112,7 +103,6 @@ jobs:
           - ubuntu-latest
         ansible-version:
           - stable-2.9
-          - stable-2.12
           - stable-2.13
           - stable-2.14
           - stable-2.15

--- a/.github/workflows/unit_source.yml
+++ b/.github/workflows/unit_source.yml
@@ -8,7 +8,6 @@ on:
         default: ""
       matrix_exclude:
         # https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html#ansible-core-support-matrix
-        # 2.12 supports Python 3.8-3.10
         # 2.13 supports Python 3.8-3.10
         # 2.14 supports Python 3.9-3.11
         # 2.15 supports Python 3.9-3.11
@@ -18,10 +17,6 @@ on:
         # devel is 2.16 until 2023-09-18
         default: >-
           [
-            {
-              "ansible-version": "stable-2.12",
-              "python-version": "3.11"
-            },
             {
               "ansible-version": "stable-2.13",
               "python-version": "3.11"
@@ -61,7 +56,6 @@ jobs:
       matrix:
         ansible-version:
           # ansible 2.9 does install from git
-          - stable-2.12
           - stable-2.13
           - stable-2.14
           - stable-2.15


### PR DESCRIPTION
Both https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html#ansible-core-support-matrix and https://access.redhat.com/support/policy/updates/ansible-automation-platform (under AAP 2.1) are fully EOL now.