### PR TITLE
changelog workflow update

### DIFF
--- a/.github/actions/ansible_validate_changelog/action.yml
+++ b/.github/actions/ansible_validate_changelog/action.yml
@@ -1,5 +1,5 @@
-name: tox
-description: Run tox specified environment
+name: ansible_validate_changelog
+description: Ensure a valid changelog has been added to the pull request.
 
 inputs:
   path:

--- a/.github/actions/ansible_validate_changelog/action.yml
+++ b/.github/actions/ansible_validate_changelog/action.yml
@@ -1,0 +1,33 @@
+name: tox
+description: Run tox specified environment
+
+inputs:
+  path:
+    description: |
+      Path to the collection to validate changelog from.
+    required: false
+    default: "."
+  base_ref:
+    description: The pull request base ref.
+    required: false
+    default: ${{ github.event.pull_request.base.ref }}
+
+runs:
+  using: composite
+  steps:
+    - name: Setup python
+      uses: actions/setup-python@v4
+      with:
+        python-version: "3.9"
+
+    - name: Install python dependencies
+      run: |
+        pip install -U pyyaml
+      shell: bash
+
+    - name: Validate changelog
+      run: >-
+        python3 ${{ github.action_path }}/validate_changelog.py
+        --ref ${{ inputs.base_ref }}
+      shell: bash
+      working-directory: ${{ inputs.path }}

--- a/.github/actions/ansible_validate_changelog/validate_changelog.py
+++ b/.github/actions/ansible_validate_changelog/validate_changelog.py
@@ -54,6 +54,9 @@ def is_module_or_plugin(ref: str) -> bool:
         "plugins/terminal",
         "plugins/test",
         "plugins/vars",
+        "roles/",
+        "playbooks/",
+        "meta/runtime.yml",
     )
     return ref.startswith(prefix_list)
 

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -6,30 +6,12 @@ jobs:
     runs-on: ubuntu-latest
     name: Require a changelog
     if: "!contains(github.event.pull_request.labels.*.name, 'skip-changelog')"
-    env:
-      PY_COLORS: "1"
-      source_directory: "./source"
     steps:
       - name: Checkout the collection repository
         uses: actions/checkout@v3
         with:
-          path: ${{ env.source_directory }}
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: "0"
 
-      - name: setup python
-        uses: actions/setup-python@v4
-        with:
-          python-version: "3.9"
-
-      - name: Download python script
-        run: curl -o /tmp/validate_changelog.py https://raw.githubusercontent.com/ansible-network/github_actions/main/scripts/validate_changelog.py
-
-      - name: Install python required libraries
-        run: pip install -U pyyaml
-
-      - name: Ensure a valid changelog entry exists
-        run: >-
-          python /tmp/validate_changelog.py
-          --ref ${{ github.event.pull_request.base.ref }}
-        working-directory: ${{ env.source_directory }}
+      - name: Validate changelog
+        uses: ansible-network/github_actions/.github/actions/ansible_validate_changelog@main


### PR DESCRIPTION
Fixes #116 
Some updated on changelog workflow
- changelog should be required for any updates on `roles/`, `playbooks/` or when `meta/runtime.yml` is updated
- Create reusable Github action