### PR TITLE
Support running tox with labels

### DIFF
--- a/.github/actions/tox/action.yml
+++ b/.github/actions/tox/action.yml
@@ -14,6 +14,10 @@ inputs:
     description: tox env list
     required: false
     default: ""
+  tox_labellist:
+    description: tox label list
+    required: false
+    default: ""
   tox_config_file:
     description: tox configuration file
     required: false
@@ -63,6 +67,9 @@ runs:
         if [ ! -z "${TOX_ENV_LIST}" ]; then
           PY_OPTIONS="${PY_OPTIONS} --tox-envname ${TOX_ENV_LIST}"
         fi
+        if [ ! -z "${TOX_LABEL_LIST}" ]; then
+          PY_OPTIONS="${PY_OPTIONS} --tox-labelname ${TOX_LABEL_LIST}"
+        fi
         if [ ! -z "${TOX_CONSTRAINTS}" ]; then
           PY_OPTIONS="${PY_OPTIONS} --tox-constraints-file ${TOX_CONSTRAINTS}"
         fi
@@ -73,6 +80,7 @@ runs:
       env:
         TOX_CONFIG_FILE: ${{ inputs.tox_config_file }}
         TOX_ENV_LIST: ${{ inputs.tox_envlist }}
+        TOX_LABEL_LIST: ${{ inputs.tox_labellist }}
         TOX_CONSTRAINTS: ${{ inputs.tox_constraints_file }}
         TOX_ENVIRONMENT: ${{ inputs.tox_environment }}
 
@@ -98,9 +106,13 @@ runs:
         if [ ! -z "${TOX_ENV_LIST}" ]; then
           TOX_CMD_OPTIONS="${TOX_CMD_OPTIONS} -e ${TOX_ENV_LIST}"
         fi
+        if [ ! -z "${TOX_LABEL_LIST}" ]; then
+          TOX_CMD_OPTIONS="${TOX_CMD_OPTIONS} -m ${TOX_LABEL_LIST}"
+        fi
         echo "tox_common_args=${TOX_CMD_OPTIONS}" >> $GITHUB_OUTPUT
       env:
         TOX_CONFIG_FILE: ${{ inputs.tox_config_file }}
+        TOX_LABEL_LIST: ${{ inputs.tox_labellist }}
         TOX_ENV_LIST: ${{ inputs.tox_envlist }}
 
     - name: Set environment variables

--- a/.github/actions/tox/install_packages.py
+++ b/.github/actions/tox/install_packages.py
@@ -24,6 +24,7 @@ logger = logging.getLogger("install_sibling")
 logger.setLevel(logging.DEBUG)
 
 
+# pylint: disable-next=too-many-arguments
 def run_tox_command(
     project_dir: PosixPath,
     env_name: Optional[str],

--- a/.github/actions/tox/install_packages.py
+++ b/.github/actions/tox/install_packages.py
@@ -27,6 +27,7 @@ logger.setLevel(logging.DEBUG)
 def run_tox_command(
     project_dir: PosixPath,
     env_name: Optional[str],
+    label_name: Optional[str],
     config_file: Optional[PosixPath],
     env_vars: Optional[dict[Any, Any]],
     extra_args: list[str],
@@ -35,6 +36,7 @@ def run_tox_command(
 
     :param project_dir: The location of the project containing tox.ini file.
     :param env_name: An optional tox env name.
+    :param label_name: An optional tox label name.
     :param config_file: An optional tox configuration file.
     :param env_vars: An optional dictionary of environment to set when running command.
     :param extra_args: Tox extra args.
@@ -43,6 +45,8 @@ def run_tox_command(
     tox_cmd = ["tox"]
     if env_name:
         tox_cmd.extend(["-e", env_name])
+    if label_name:
+        tox_cmd.extend(["-m", label_name])
     if config_file:
         tox_cmd.extend(["-c", str(config_file)])
     if extra_args:
@@ -320,12 +324,15 @@ def main() -> None:
     parser.add_argument(
         "--tox-config-file", type=PosixPath, help="the location of the tox configuration file"
     )
-    parser.add_argument("--tox-envname", help="the tox env name. e.g: env1=value1\nenv2=value2")
+    parser.add_argument("--tox-envname", help="the tox env name.")
+    parser.add_argument("--tox-labelname", help="the tox label name.")
     parser.add_argument(
         "--tox-project-dir", default=".", help="the location of the project containing tox.ini file"
     )
     parser.add_argument(
-        "--tox-env-vars", default="", help="the environment to set when running tox command."
+        "--tox-env-vars",
+        default="",
+        help="the environment to set when running tox command. e.g: env1=value1\nenv2=value2",
     )
     parser.add_argument(
         "--tox-constraints-file", type=PosixPath, help="the location to the tox constraints file."
@@ -352,13 +359,23 @@ def main() -> None:
     if tox_extra_args:
         extra_args.append(tox_extra_args)
     run_tox_command(
-        args.tox_project_dir, args.tox_envname, args.tox_config_file, tox_environment, extra_args
+        args.tox_project_dir,
+        args.tox_envname,
+        args.tox_labelname,
+        args.tox_config_file,
+        tox_environment,
+        extra_args,
     )
 
     # show environment config
     extra_args = ["--showconfig"]
     tox_raw_config = run_tox_command(
-        args.tox_project_dir, args.tox_envname, args.tox_config_file, tox_environment, extra_args
+        args.tox_project_dir,
+        args.tox_envname,
+        args.tox_labelname,
+        args.tox_config_file,
+        tox_environment,
+        extra_args,
     )
     logger.info("Show config => %s", tox_raw_config)
 

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -1,0 +1,28 @@
+name: tox
+on:
+  workflow_call:
+    inputs:
+      envname:
+        description: Tox environment name to use to limit the run
+        required: false
+        type: string
+        default: ""
+      labelname:
+        description: Tox label to use to limit the run
+        required: false
+        type: string
+        default: ""
+jobs:
+  tox:
+    runs-on: ubuntu-latest
+    name: Run Tox based code tests
+    steps:
+      - name: Code checkout
+        uses: actions/checkout@v3
+
+      - name: Run tests
+        uses: ansible-network/github_actions/.github/actions/tox@main
+        with:
+          path: "."
+          tox_envlist: ${{ inputs.envname }}
+          tox_labellist: ${{ inputs.labelname }}


### PR DESCRIPTION
Tox v4 added support for labels.

These mean that instead of pulling multiple shell commands into  one environment, or passing multiple environment names to the tox command we can pass a single label name to trigger multiple environments to run (for example running `tox -m lint` on https://github.com/tremble/amazon.aws/commit/b281b9950d83db1da9d21137591ff348bbeefa15 will run flake8, isort, black and generate the complexity report)

This PR adds support for labels to the action and a new generic tox workflow that doesn't hard code the "linters" environment (reduces the potential for breaking an existing workflow).