### PR TITLE
Remove stable-2.9 and stable-2.13 support and add stable-2.16 support.

### DIFF
--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -33,6 +33,19 @@ on:
           ]
         required: false
         type: string
+      matrix_include:
+        # python 3.6 is not available after ubuntu-20.04
+        # python 3.6 is not supported on ansible 2.12+
+        default: >-
+          [
+            {
+              "os": "ubuntu-20.04",
+              "ansible-version": "stable-2.9",
+              "python-version": "3.6"
+            },
+          ]
+        required: false
+        type: string
       unstable:
         default: >-
           [

--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -19,78 +19,17 @@ on:
         default: >-
           [
             {
-              "ansible-version": "stable-2.9",
+              "ansible-version": "stable-2.16",
               "python-version": "3.9"
-            },
-            {
-              "ansible-version": "stable-2.9",
-              "python-version": "3.10"
-            },
-            {
-              "ansible-version": "stable-2.9",
-              "python-version": "3.11"
-            },
-            {
-              "ansible-version": "stable-2.13",
-              "python-version": "3.7"
-            },
-            {
-              "ansible-version": "stable-2.13",
-              "python-version": "3.11"
-            },
-            {
-              "ansible-version": "stable-2.14",
-              "python-version": "3.7"
-            },
-            {
-              "ansible-version": "stable-2.14",
-              "python-version": "3.8"
-            },
-            {
-              "ansible-version": "stable-2.15",
-              "python-version": "3.7"
-            },
-            {
-              "ansible-version": "stable-2.15",
-              "python-version": "3.8"
-            },
-            {
-              "ansible-version": "milestone",
-              "python-version": "3.7"
-            },
-            {
-              "ansible-version": "milestone",
-              "python-version": "3.8"
             },
             {
               "ansible-version": "milestone",
               "python-version": "3.9"
-            },
-            {
-              "ansible-version": "devel",
-              "python-version": "3.7"
-            },
-            {
-              "ansible-version": "devel",
-              "python-version": "3.8"
             },
             {
               "ansible-version": "devel",
               "python-version": "3.9"
             }
-          ]
-        required: false
-        type: string
-      matrix_include:
-        # python 3.6 is not available after ubuntu-20.04
-        # python 3.6 is not supported on ansible 2.12+
-        default: >-
-          [
-            {
-              "os": "ubuntu-20.04",
-              "ansible-version": "stable-2.9",
-              "python-version": "3.6"
-            },
           ]
         required: false
         type: string
@@ -113,15 +52,12 @@ jobs:
         os:
           - ubuntu-latest
         ansible-version:
-          - stable-2.9
-          - stable-2.13
           - stable-2.14
           - stable-2.15
+          - stable-2.16
           - milestone
           - devel
         python-version:
-          - "3.7"
-          - "3.8"
           - "3.9"
           - "3.10"
           - "3.11"

--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -8,16 +8,22 @@ on:
         default: ""
       matrix_exclude:
         # https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html#ansible-core-support-matrix
-        # 2.9 supports Python 3.5-3.8
-        # 2.13 supports Python 3.8-3.10
         # 2.14 supports Python 3.9-3.11
         # 2.15 supports Python 3.9-3.11
-        # 2.16 supports Python 3.10-3.11
-        # https://docs.ansible.com/ansible/devel/roadmap/ROADMAP_2_16.html
-        # milestone is 2.16 until after 2.16 branches from devel
-        # devel is 2.16 until 2023-09-18
+        # 2.16 supports Python 3.10-3.12
+        # https://docs.ansible.com/ansible/devel/roadmap/ROADMAP_2_17.html
+        # milestone is 2.17 until after 2.17 branches from devel
+        # devel is 2.17 until 2024-04-01
         default: >-
           [
+            {
+              "ansible-version": "stable-2.14",
+              "python-version": "3.12"
+            },
+            {
+              "ansible-version": "stable-2.15",
+              "python-version": "3.12"
+            },
             {
               "ansible-version": "stable-2.16",
               "python-version": "3.9"
@@ -34,8 +40,6 @@ on:
         required: false
         type: string
       matrix_include:
-        # python 3.6 is not available after ubuntu-20.04
-        # python 3.6 is not supported on ansible 2.12+
         default: []
         required: false
         type: string
@@ -67,6 +71,7 @@ jobs:
           - "3.9"
           - "3.10"
           - "3.11"
+          - "3.12"
         exclude: ${{ fromJSON(inputs.matrix_exclude) }}
         include: ${{ fromJSON(inputs.matrix_include) }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -36,14 +36,7 @@ on:
       matrix_include:
         # python 3.6 is not available after ubuntu-20.04
         # python 3.6 is not supported on ansible 2.12+
-        default: >-
-          [
-            {
-              "os": "ubuntu-20.04",
-              "ansible-version": "stable-2.9",
-              "python-version": "3.6"
-            },
-          ]
+        default: []
         required: false
         type: string
       unstable:

--- a/.github/workflows/unit_source.yml
+++ b/.github/workflows/unit_source.yml
@@ -18,28 +18,12 @@ on:
         default: >-
           [
             {
-              "ansible-version": "stable-2.13",
-              "python-version": "3.11"
-            },
-            {
-              "ansible-version": "stable-2.14",
-              "python-version": "3.8"
-            },
-            {
-              "ansible-version": "stable-2.15",
-              "python-version": "3.8"
-            },
-            {
-              "ansible-version": "milestone",
-              "python-version": "3.8"
+              "ansible-version": "table-2.16",
+              "python-version": "3.9"
             },
             {
               "ansible-version": "milestone",
               "python-version": "3.9"
-            },
-            {
-              "ansible-version": "devel",
-              "python-version": "3.8"
             },
             {
               "ansible-version": "devel",
@@ -60,13 +44,12 @@ jobs:
       matrix:
         ansible-version:
           # ansible 2.9 does install from git
-          - stable-2.13
           - stable-2.14
           - stable-2.15
+          - stable-2.16
           - milestone
           - devel
         python-version:
-          - "3.8"
           - "3.9"
           - "3.10"
           - "3.11"

--- a/.github/workflows/unit_source.yml
+++ b/.github/workflows/unit_source.yml
@@ -18,7 +18,7 @@ on:
         default: >-
           [
             {
-              "ansible-version": "table-2.16",
+              "ansible-version": "stable-2.16",
               "python-version": "3.9"
             },
             {

--- a/.github/workflows/unit_source.yml
+++ b/.github/workflows/unit_source.yml
@@ -8,15 +8,22 @@ on:
         default: ""
       matrix_exclude:
         # https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html#ansible-core-support-matrix
-        # 2.13 supports Python 3.8-3.10
         # 2.14 supports Python 3.9-3.11
         # 2.15 supports Python 3.9-3.11
-        # 2.16 supports Python 3.10-3.11
-        # https://docs.ansible.com/ansible/devel/roadmap/ROADMAP_2_16.html
-        # milestone is 2.16 until after 2.16 branches from devel
-        # devel is 2.16 until 2023-09-18
+        # 2.16 supports Python 3.10-3.12
+        # https://docs.ansible.com/ansible/devel/roadmap/ROADMAP_2_17.html
+        # milestone is 2.17 until after 2.17 branches from devel
+        # devel is 2.17 until 2024-04-01
         default: >-
           [
+            {
+              "ansible-version": "stable-2.14",
+              "python-version": "3.12"
+            },
+            {
+              "ansible-version": "stable-2.15",
+              "python-version": "3.12"
+            },
             {
               "ansible-version": "stable-2.16",
               "python-version": "3.9"
@@ -53,6 +60,7 @@ jobs:
           - "3.9"
           - "3.10"
           - "3.11"
+          - "3.12"
         exclude: ${{ fromJSON(inputs.matrix_exclude) }}
     continue-on-error: ${{ matrix.ansible-version == 'devel' }}
 


### PR DESCRIPTION
Ansible-core 2.13 is scheduled for EoL on November 26, 2023, and the stable-2.16 branch is released

Tested with https://github.com/ansible-collections/kubernetes.core/pull/655