### PR TITLE
[sanity] exclude milestone x Py3.12 test temporarily

### DIFF
--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -33,6 +33,10 @@ on:
               "python-version": "3.9"
             },
             {
+              "ansible-version": "milestone",
+              "python-version": "3.12"
+            },
+            {
               "ansible-version": "devel",
               "python-version": "3.9"
             }

--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -32,6 +32,7 @@ on:
               "ansible-version": "milestone",
               "python-version": "3.9"
             },
+            # remove this when milestone is next forwarded
             {
               "ansible-version": "milestone",
               "python-version": "3.12"


### PR DESCRIPTION
This is currently failing due to missing `rstcheck_core`. 

Logs: https://github.com/ansible-collections/ibm.qradar/actions/runs/6819043963/job/18550121556

Since this passes with devel, this might already be fixed and we have to wait until milestone is forwarded next.