### PR TITLE
Fix bug in sanity workflow matrix_exclude

### DIFF
--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -14,6 +14,7 @@ on:
         # https://docs.ansible.com/ansible/devel/roadmap/ROADMAP_2_17.html
         # milestone is 2.17 until after 2.17 branches from devel
         # devel is 2.17 until 2024-04-01
+        # remove 3.12/milestone from matrix_exclude when milestone is next forwarded
         default: >-
           [
             {
@@ -32,7 +33,6 @@ on:
               "ansible-version": "milestone",
               "python-version": "3.9"
             },
-            # remove this when milestone is next forwarded
             {
               "ansible-version": "milestone",
               "python-version": "3.12"


### PR DESCRIPTION
Comment in sanity workflow was causing a JSON parsing error, see https://github.com/redhat-cop/cloud.gcp_ops/actions/runs/6867140681. This just moves the comment outside the field value.

Fixes #130 