### PR TITLE
Add extra install steps for ansible-pylibssh when running with Py3.12

### DIFF
--- a/.github/workflows/unit_galaxy.yml
+++ b/.github/workflows/unit_galaxy.yml
@@ -136,6 +136,20 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+      
+      # ansible-pylibssh does not have cp312 wheels
+      # when building from sdist libssh-dev needs to be installed
+      # extra install step starts
+      - name: Install build toolchain and openssl headers on Linux
+        shell: bash
+        run: sudo apt update && sudo apt install build-essential libssl-dev
+        if: ${{ matrix.python-version == 3.12 }}
+
+      - name: Install catchsegv and libssh headers on Linux for cythonize+coverage
+        shell: bash
+        run: sudo apt update && sudo apt install libssh-dev
+        if: ${{ matrix.python-version == 3.12 }}
+      # extra install step ends
 
       - name: Install ansible-core (${{ matrix.ansible-version }})
         run: python3 -m pip install https://github.com/ansible/ansible/archive/${{ matrix.ansible-version }}.tar.gz --disable-pip-version-check

--- a/.github/workflows/unit_galaxy.yml
+++ b/.github/workflows/unit_galaxy.yml
@@ -136,7 +136,7 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-      
+
       # ansible-pylibssh does not have cp312 wheels
       # when building from sdist libssh-dev needs to be installed
       # extra install step starts

--- a/.github/workflows/unit_source.yml
+++ b/.github/workflows/unit_source.yml
@@ -77,7 +77,7 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-      
+
       # ansible-pylibssh does not have cp312 wheels
       # when building from sdist libssh-dev needs to be installed
       # extra install step starts

--- a/.github/workflows/unit_source.yml
+++ b/.github/workflows/unit_source.yml
@@ -77,6 +77,20 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+      
+      # ansible-pylibssh does not have cp312 wheels
+      # when building from sdist libssh-dev needs to be installed
+      # extra install step starts
+      - name: Install build toolchain and openssl headers on Linux
+        shell: bash
+        run: sudo apt update && sudo apt install build-essential libssl-dev
+        if: ${{ matrix.python-version == 3.12 }}
+
+      - name: Install catchsegv and libssh headers on Linux for cythonize+coverage
+        shell: bash
+        run: sudo apt update && sudo apt install libssh-dev
+        if: ${{ matrix.python-version == 3.12 }}
+      # extra install step ends
 
       - name: Install ansible-core (${{ matrix.ansible-version }})
         run: python3 -m pip install https://github.com/ansible/ansible/archive/${{ matrix.ansible-version }}.tar.gz --disable-pip-version-check


### PR DESCRIPTION
Original work by @KB-perByte.

### Summary

- ansible-pylibssh does not have cp312 wheels
- when building from sdist, libssh-dev needs to be installed
- Failure logs - https://github.com/ansible-collections/ansible.netcommon/actions/runs/6977967067/job/18993790989?pr=604