### PR TITLE
Enable 2.16 in integration tests

### DIFF
--- a/.github/workflows/integration_simple.yml
+++ b/.github/workflows/integration_simple.yml
@@ -43,6 +43,10 @@ on:
               "python-version": "3.8"
             },
             {
+              "ansible-version": "stable-2.16",
+              "python-version": "3.9"
+            },
+            {
               "ansible-version": "milestone",
               "python-version": "3.8"
             },

--- a/.github/workflows/integration_simple.yml
+++ b/.github/workflows/integration_simple.yml
@@ -43,10 +43,6 @@ on:
               "python-version": "3.8"
             },
             {
-              "ansible-version": "stable-2.16",
-              "python-version": "3.9"
-            },
-            {
               "ansible-version": "milestone",
               "python-version": "3.8"
             },
@@ -87,6 +83,7 @@ jobs:
           - stable-2.13
           - stable-2.14
           - stable-2.15
+          - stable-2.16
           - milestone
           - devel
         python-version:

--- a/.github/workflows/unit_galaxy.yml
+++ b/.github/workflows/unit_galaxy.yml
@@ -55,10 +55,6 @@ on:
               "python-version": "3.8"
             },
             {
-              "ansible-version": "stable-2.16",
-              "python-version": "3.9"
-            },
-            {
               "ansible-version": "milestone",
               "python-version": "3.7"
             },
@@ -114,6 +110,7 @@ jobs:
           - stable-2.13
           - stable-2.14
           - stable-2.15
+          - stable-2.16
           - milestone
           - devel
         python-version:

--- a/.github/workflows/unit_galaxy.yml
+++ b/.github/workflows/unit_galaxy.yml
@@ -55,6 +55,10 @@ on:
               "python-version": "3.8"
             },
             {
+              "ansible-version": "stable-2.16",
+              "python-version": "3.9"
+            },
+            {
               "ansible-version": "milestone",
               "python-version": "3.7"
             },


### PR DESCRIPTION
Enable 2.16 in integration tests
- ansible.utils