### PR TITLE
Add --ansible-host-pattern localhost to pytest to support py3.9

### DIFF
--- a/.github/workflows/unit_source.yml
+++ b/.github/workflows/unit_source.yml
@@ -120,5 +120,5 @@ jobs:
         run: python3 -m pip list
 
       - name: Run unit tests
-        run: python -m pytest tests/unit --showlocals
+        run: python -m pytest tests/unit --showlocals --ansible-host-pattern localhost
         working-directory: ${{ steps.identify.outputs.collection_path }}


### PR DESCRIPTION
Unit tests fail for stable 2.14,2.15 in py 3.9. Adding `--ansible-host-pattern localhost` to pytest to fix the failure.
Refer: https://github.com/ansible-collections/kubernetes.core/actions/runs/7671235861/job/20909165750#step:12:14