### PR TITLE
Add plugin_utils to validate changelog action

### DIFF
--- a/.github/actions/ansible_validate_changelog/validate_changelog.py
+++ b/.github/actions/ansible_validate_changelog/validate_changelog.py
@@ -38,6 +38,7 @@ def is_module_or_plugin(ref: str) -> bool:
     prefix_list = (
         "plugins/modules",
         "plugins/module_utils",
+        "plugins/plugin_utils",
         "plugins/action",
         "plugins/inventory",
         "plugins/lookup",


### PR DESCRIPTION
The validate changelog script was missing plugins/plugin_utils from its list of directories.