### PR TITLE
Lab title based on events - intergration tests for network collections

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -6,6 +6,10 @@ on:
         required: false
         type: string
         default: ""
+      lab_title:
+        required: false
+        type: string
+        default: ""
       cml_lab:
         default: tests/integration/labs/single.yaml
         required: false
@@ -103,6 +107,24 @@ jobs:
           VIRL_HOST: ${{ secrets.virl_host }}
           VIRL_PASSWORD: ${{ secrets.virl_password }}
           VIRL_USERNAME: admin
+
+      - name: Create the lab title
+        run: |
+          if [[ "${{ github.event_name }}" == 'pull_request_target' ]]; then
+            echo "CLABTITLE=${{ inputs.lab_title }}_PR${{ github.event.pull_request.number }}" >> $GITHUB_ENV
+          elif [[ "${{ github.event_name }}" == 'workflow_dispatch' ]]; then
+            shashort=$(echo ${{ github.sha }} | cut -c 1-30)
+            uuidval=$(uuidgen | cut -c 1-8)
+            echo "CLABTITLE=${{ inputs.lab_title }}_${shashort}_${uuidval}" >> $GITHUB_ENV
+          fi
+
+      - name: Print the lab title
+        run: echo ${{ env.CLABTITLE }}
+
+      - name: Add Lab Title to the lab file
+        run: >-
+          sed -i "s/title: ${{ inputs.network_os }}/title: ${{ env.CLABTITLE }}/" ${{ inputs.cml_lab }}
+        working-directory: ${{ steps.identify.outputs.collection_path }}
 
       - name: Run integration tests
         run: >-

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -9,7 +9,7 @@ on:
       lab_title:
         required: false
         type: string
-        default: ""
+        default: ${{ github.event.repository.name }}
       cml_lab:
         default: tests/integration/labs/single.yaml
         required: false
@@ -113,7 +113,7 @@ jobs:
           if [[ "${{ github.event_name }}" == 'pull_request_target' ]]; then
             echo "CLABTITLE=${{ inputs.lab_title }}_PR${{ github.event.pull_request.number }}" >> $GITHUB_ENV
           elif [[ "${{ github.event_name }}" == 'workflow_dispatch' ]]; then
-            shashort=$(echo ${{ github.sha }} | cut -c 1-30)
+            shashort=$(git rev-parse --short ${{ github.sha }})
             uuidval=$(uuidgen | cut -c 1-8)
             echo "CLABTITLE=${{ inputs.lab_title }}_${shashort}_${uuidval}" >> $GITHUB_ENV
           fi

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -113,7 +113,7 @@ jobs:
           if [[ "${{ github.event_name }}" == 'pull_request_target' ]]; then
             echo "CLABTITLE=${{ inputs.lab_title }}_PR${{ github.event.pull_request.number }}" >> $GITHUB_ENV
           elif [[ "${{ github.event_name }}" == 'workflow_dispatch' ]]; then
-            shashort=$(git rev-parse --short ${{ github.sha }})
+            shashort=$(git rev-parse --short HEAD)
             uuidval=$(uuidgen | cut -c 1-8)
             echo "CLABTITLE=${{ inputs.lab_title }}_${shashort}_${uuidval}" >> $GITHUB_ENV
           fi

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -9,7 +9,7 @@ on:
       lab_title:
         required: false
         type: string
-        default: ${{ github.event.repository.name }}
+        default: ""
       cml_lab:
         default: tests/integration/labs/single.yaml
         required: false
@@ -113,7 +113,7 @@ jobs:
           if [[ "${{ github.event_name }}" == 'pull_request_target' ]]; then
             echo "CLABTITLE=${{ inputs.lab_title }}_PR${{ github.event.pull_request.number }}" >> $GITHUB_ENV
           elif [[ "${{ github.event_name }}" == 'workflow_dispatch' ]]; then
-            shashort=$(git rev-parse --short ${{ github.sha }})
+            shashort=$(echo ${{ github.sha }} | cut -c 1-30)
             uuidval=$(uuidgen | cut -c 1-8)
             echo "CLABTITLE=${{ inputs.lab_title }}_${shashort}_${uuidval}" >> $GITHUB_ENV
           fi

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,7 +7,7 @@
   "isort.check": true,
   "[python]": {
     "editor.codeActionsOnSave": {
-      "source.organizeImports": true
+      "source.organizeImports": "explicit"
     }
   },
   "prettier.enable": true

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,7 +7,7 @@
   "isort.check": true,
   "[python]": {
     "editor.codeActionsOnSave": {
-      "source.organizeImports": "explicit"
+      "source.organizeImports": true
     }
   },
   "prettier.enable": true


### PR DESCRIPTION
Creates the labtitle based on the github action event triggered and appends the lab title to `single.yml` file.

Below is the specific job that does it:
```yaml
- name: Create the lab title
  run: |
    if [[ "${{ github.event_name }}" == 'pull_request_target' ]]; then
      echo "CLABTITLE=${{ inputs.lab_title }}_PR${{ github.event.pull_request.number }}" >> $GITHUB_ENV
    elif [[ "${{ github.event_name }}" == 'workflow_dispatch' ]]; then
      shashort=$(echo ${{ github.sha }} | cut -c 1-30)
      uuidval=$(uuidgen | cut -c 1-8)
      echo "CLABTITLE=${{ inputs.lab_title }}_${shashort}_${uuidval}" >> $GITHUB_ENV
    fi
```