### PR TITLE
ansible_validate_changelog - add the possibility to define custom paths

### DIFF
--- a/.github/actions/ansible_validate_changelog/action.yml
+++ b/.github/actions/ansible_validate_changelog/action.yml
@@ -11,6 +11,11 @@ inputs:
     description: The pull request base ref.
     required: false
     default: ${{ github.event.pull_request.base.ref }}
+  custom_paths:
+    description: |
+      A comma-separated list of custom paths from which any modified file
+      will require a changelog.
+    default: ""
 
 runs:
   using: composite
@@ -29,5 +34,6 @@ runs:
       run: >-
         python3 ${{ github.action_path }}/validate_changelog.py
         --ref ${{ inputs.base_ref }}
+        --custom-paths ${{ inputs.custom_paths }}
       shell: bash
       working-directory: ${{ inputs.path }}

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,6 +1,14 @@
 name: Changelog required
 on:
   workflow_call:
+    inputs:
+      custom_paths:
+        description: |
+          A comma-separated list of custom paths from which any modified file
+          will require a changelog.
+        required: false
+        type: string
+        default: ""
 jobs:
   changelog:
     runs-on: ubuntu-latest
@@ -15,3 +23,5 @@ jobs:
 
       - name: Validate changelog
         uses: ansible-network/github_actions/.github/actions/ansible_validate_changelog@main
+        with:
+          custom_paths: ${{ inputs.custom_paths }}


### PR DESCRIPTION
The `ansible_validate_changelog` Github action is designed for Ansible collections as it will check changes from path `plugins/*`, `roles/`, `playbook/`. 
This pull request adds the possibility to define custom paths to check changes in