### PR TITLE
Validate changelog default value

### DIFF
--- a/.github/actions/ansible_validate_changelog/action.yml
+++ b/.github/actions/ansible_validate_changelog/action.yml
@@ -30,10 +30,19 @@ runs:
         pip install -U pyyaml
       shell: bash
 
-    - name: Validate changelog
+    - name: Validate changelog using custom paths
       run: >-
         python3 ${{ github.action_path }}/validate_changelog.py
         --ref ${{ inputs.base_ref }}
         --custom-paths ${{ inputs.custom_paths }}
       shell: bash
       working-directory: ${{ inputs.path }}
+      if: inputs.custom_paths != ''
+
+    - name: Validate changelog
+      run: >-
+        python3 ${{ github.action_path }}/validate_changelog.py
+        --ref ${{ inputs.base_ref }}
+      shell: bash
+      working-directory: ${{ inputs.path }}
+      if: inputs.custom_paths == ''


### PR DESCRIPTION
Fixing minor bug introduced by #151 

The default value for the `custom_paths` has been set to `""` this means when the workflow is called without overriding this the action is trying to run the command `validate_changelog.py --ref main --custom-paths` which produces the following error `validate_changelog.py: error: argument --custom-paths: expected one argument`

This has been tested here https://github.com/abikouo/gha_testing/actions/runs/8726044441/job/23940402498?pr=133