### PR TITLE
Do not test for ansible-core < 2.15

### DIFF
--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -68,7 +68,6 @@ jobs:
         os:
           - ubuntu-latest
         ansible-version:
-          - stable-2.14
           - stable-2.15
           - stable-2.16
           - milestone


### PR DESCRIPTION
Do not test for ansible-core < 2.15 since 2.14 is EOL next Monday. https://github.com/ansible-collections/cloud-content-handbook/blob/main/Release/release_collections.md#release-cycle-for-supported-collections. 