### PR TITLE
Remove ansible-core==2.14 from unit tests worflow matrix

### DIFF
--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -8,7 +8,6 @@ on:
         default: ""
       matrix_exclude:
         # https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html#ansible-core-support-matrix
-        # 2.14 supports Python 3.9-3.11
         # 2.15 supports Python 3.9-3.11
         # 2.16 supports Python 3.10-3.12
         # https://docs.ansible.com/ansible/devel/roadmap/ROADMAP_2_17.html
@@ -17,10 +16,6 @@ on:
         # remove 3.12/milestone from matrix_exclude when milestone is next forwarded
         default: >-
           [
-            {
-              "ansible-version": "stable-2.14",
-              "python-version": "3.12"
-            },
             {
               "ansible-version": "stable-2.15",
               "python-version": "3.12"

--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -10,6 +10,7 @@ on:
         # https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html#ansible-core-support-matrix
         # 2.15 supports Python 3.9-3.11
         # 2.16 supports Python 3.10-3.12
+        # 2.17 supports Python 3.10-3.12
         # https://docs.ansible.com/ansible/devel/roadmap/ROADMAP_2_17.html
         # milestone is 2.17 until after 2.17 branches from devel
         # devel is 2.17 until 2024-04-01
@@ -22,6 +23,10 @@ on:
             },
             {
               "ansible-version": "stable-2.16",
+              "python-version": "3.9"
+            },
+            {
+              "ansible-version": "stable-2.17",
               "python-version": "3.9"
             },
             {
@@ -65,6 +70,7 @@ jobs:
         ansible-version:
           - stable-2.15
           - stable-2.16
+          - stable-2.17
           - milestone
           - devel
         python-version:

--- a/.github/workflows/unit_galaxy.yml
+++ b/.github/workflows/unit_galaxy.yml
@@ -8,7 +8,6 @@ on:
         default: ""
       matrix_exclude:
         # https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html#ansible-core-support-matrix
-        # 2.14 supports Python 3.9-3.11
         # 2.15 supports Python 3.9-3.11
         # 2.16 supports Python 3.10-3.11
         # https://docs.ansible.com/ansible/devel/roadmap/ROADMAP_2_16.html
@@ -16,10 +15,6 @@ on:
         # devel is 2.16 until 2023-09-18
         default: >-
           [
-            {
-              "ansible-version": "stable-2.14",
-              "python-version": "3.12"
-            },
             {
               "ansible-version": "stable-2.15",
               "python-version": "3.12"
@@ -60,7 +55,6 @@ jobs:
         os:
           - ubuntu-latest
         ansible-version:
-          - stable-2.14
           - stable-2.15
           - stable-2.16
           - milestone

--- a/.github/workflows/unit_galaxy.yml
+++ b/.github/workflows/unit_galaxy.yml
@@ -24,6 +24,10 @@ on:
               "python-version": "3.9"
             },
             {
+              "ansible-version": "stable-2.17",
+              "python-version": "3.9"
+            },
+            {
               "ansible-version": "milestone",
               "python-version": "3.9"
             },
@@ -57,6 +61,7 @@ jobs:
         ansible-version:
           - stable-2.15
           - stable-2.16
+          - stable-2.17
           - milestone
           - devel
         python-version:

--- a/.github/workflows/unit_source.yml
+++ b/.github/workflows/unit_source.yml
@@ -11,8 +11,8 @@ on:
         # 2.15 supports Python 3.9-3.11
         # 2.16 supports Python 3.10-3.12
         # https://docs.ansible.com/ansible/devel/roadmap/ROADMAP_2_17.html
-        # milestone is 2.17 until after 2.17 branches from devel
-        # devel is 2.17 until 2024-04-01
+        # milestone is 2.18
+        # devel is 2.18 until xxxx-xx-xx
         default: >-
           [
             {
@@ -21,6 +21,10 @@ on:
             },
             {
               "ansible-version": "stable-2.16",
+              "python-version": "3.9"
+            },
+            {
+              "ansible-version": "stable-2.17",
               "python-version": "3.9"
             },
             {
@@ -47,6 +51,7 @@ jobs:
         ansible-version:
           - stable-2.15
           - stable-2.16
+          - stable-2.17
           - milestone
           - devel
         python-version:

--- a/.github/workflows/unit_source.yml
+++ b/.github/workflows/unit_source.yml
@@ -8,7 +8,6 @@ on:
         default: ""
       matrix_exclude:
         # https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html#ansible-core-support-matrix
-        # 2.14 supports Python 3.9-3.11
         # 2.15 supports Python 3.9-3.11
         # 2.16 supports Python 3.10-3.12
         # https://docs.ansible.com/ansible/devel/roadmap/ROADMAP_2_17.html
@@ -16,10 +15,6 @@ on:
         # devel is 2.17 until 2024-04-01
         default: >-
           [
-            {
-              "ansible-version": "stable-2.14",
-              "python-version": "3.12"
-            },
             {
               "ansible-version": "stable-2.15",
               "python-version": "3.12"
@@ -50,7 +45,6 @@ jobs:
       fail-fast: false
       matrix:
         ansible-version:
-          - stable-2.14
           - stable-2.15
           - stable-2.16
           - milestone


### PR DESCRIPTION
`ansible-core==2.14` is no longer supported. 
This PR aims to remove `stable-2.14` from unit tests worflow matrix.