### PR TITLE
Bump python version in actions/tox to 3.10

### DIFF
--- a/.github/actions/tox/action.yml
+++ b/.github/actions/tox/action.yml
@@ -50,7 +50,7 @@ runs:
     - name: setup python
       uses: actions/setup-python@v4
       with:
-        python-version: "3.9"
+        python-version: "3.10"
 
     - name: Install tox
       run: pip install -U tox


### PR DESCRIPTION
To bump ansible-lint version to 24.7.0 in amazon.aws, python >= 3.10 is required.
https://github.com/ansible-collections/amazon.aws/pull/2201


```
ERROR: Ignored the following versions that require a different python version: 24.2.0 Requires-Python >=3.10; 24.2.1 Requires-Python >=3.10; 24.2.2 Requires-Python >=3.10; 24.2.3 Requires-Python >=3.10; 24.5.0 Requires-Python >=3.10; 24.6.0 Requires-Python >=3.10; 24.6.1 Requires-Python >=3.10; 24.7.0 Requires-Python >=3.10
ERROR: Could not find a version that satisfies the requirement ansible-lint>=24.7.0 (from versions: 1.0.0, 1.0.1, 1.0.2, 1.0.3, 1.0.4, 2.0.1, 2.0.3, 2.1.0, 2.1.3, 2.2.0, 2.3.0, 2.3.1, 2.3.2, 2.3.3, 2.3.5, 2.3.6, 2.3.8, 2.3.9, 2.4.0, 2.4.1, 2.4.2, 2.5.0, 2.6.1, 2.6.2, 2.7.0rc1, 2.7.0, 2.7.1, 3.0.0rc1, 3.0.0rc2, 3.0.0rc3, 3.0.0rc4, 3.0.0rc5, 3.0.0rc6, 3.0.0rc7, 3.0.0rc8, 3.0.0rc9, 3.0.0rc10, 3.0.0rc11, 3.0.0rc12, 3.0.0, 3.0.1, 3.0.2rc1, 3.1.0rc1, 3.1.0, 3.1.1, 3.1.2, 3.1.3, 3.2.0, 3.2.1rc1, 3.2.1rc2, 3.2.1, 3.2.2rc1, 3.2.2, 3.2.3, 3.2.4, 3.2.5, 3.3.0rc1, 3.3.0rc2, 3.3.0rc3, 3.3.0rc4, 3.3.0, 3.3.2, 3.3.3, 3.4.0rc1, 3.4.0rc2, 3.4.0, 3.4.1, 3.4.3, 3.4.4, 3.4.5, 3.4.6, 3.4.7, 3.4.8, 3.4.9, 3.4.10, 3.4.11, 3.4.12, 3.4.13, 3.4.15, 3.4.16, 3.4.17, 3.4.18, 3.4.19, 3.4.20, 3.4.21, 3.4.22, 3.4.23, 3.5.0rc1, 3.5.0, 3.5.1, 4.0.0a1, 4.0.0a2, 4.0.0, 4.0.1, 4.1.0a0, 4.1.0, 4.1.1a0, 4.1.1a1, 4.1.1a2, 4.1.1a3, 4.1.1a4, 4.1.1a5, 4.1.1a6, 4.2.0a1, 4.2.0rc1, 4.2.0rc2, 4.2.0, 4.3.0a0, 4.3.0a1, 4.3.0a2, 4.3.0a3, 4.3.0a4, 4.3.0a5, 4.3.0a6, 4.3.0, 4.3.1, 4.3.2, 4.3.3, 4.3.4, 4.3.5, 4.3.6, 4.3.7, 5.0.0, 5.0.1, 5.0.2, 5.0.3a0, 5.0.3a1, 5.0.3rc1, 5.0.3, 5.0.4, 5.0.5a0, 5.0.5a1, 5.0.5, 5.0.6, 5.0.7, 5.0.8, 5.0.9, 5.0.10, 5.0.11, 5.0.12, 5.1.0a0, 5.1.0a1, 5.1.1, 5.1.2, 5.1.3, 5.2.0, 5.2.1, 5.3.0, 5.3.1, 5.3.2, 5.4.0, 6.0.0a0, 6.0.0a1, 6.0.0, 6.0.1, 6.0.2, 6.1.0, 6.2.0a0, 6.2.0, 6.2.1, 6.2.2, 6.3.0, 6.4.0, 6.5.0, 6.5.1, 6.5.2, 6.6.0, 6.6.1, 6.7.0, 6.8.0a0, 6.8.0b1, 6.8.0b2, 6.8.0b3, 6.8.0, 6.8.1, 6.8.2, 6.8.3, 6.8.4, 6.8.5, 6.8.6, 6.8.7, 6.9.0, 6.9.1, 6.10.0a0, 6.10.0a1, 6.10.0, 6.10.1, 6.10.2, 6.11.0, 6.12.0, 6.12.1, 6.12.2, 6.13.0, 6.13.1, 6.14.0a0, 6.14.0, 6.14.1, 6.14.2, 6.14.3, 6.14.4, 6.14.6, 6.15.0, 6.16.0, 6.16.1, 6.16.2, 6.17.0, 6.17.1, 6.17.2, 6.18.0, 6.19.0, 6.20.0, 6.20.1, 6.20.2, 6.20.3, 6.21.0, 6.21.1, 6.22.0, 6.22.1, 6.22.2)
ERROR: No matching distribution found for ansible-lint>=24.7.0
```