### PR TITLE
Revert "Drop tests from ansible-core < 2.16"

### DIFF
--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -18,6 +18,22 @@ on:
         default: >-
           [
             {
+              "ansible-version": "stable-2.16",
+              "python-version": "3.9"
+            },
+            {
+              "ansible-version": "stable-2.17",
+              "python-version": "3.9"
+            },
+            {
+              "ansible-version": "milestone",
+              "python-version": "3.9"
+            },
+            {
+              "ansible-version": "devel",
+              "python-version": "3.9"
+            },
+            {
               "ansible-version": "devel",
               "python-version": "3.10"
             },
@@ -26,9 +42,9 @@ on:
               "python-version": "3.10"
             },
             {
-              "ansible-version": "stable-2.18",
-              "python-version": "3.10"
-            },
+              "ansible-version": "stable-2.15",
+              "python-version": "3.12"
+            }
           ]
         required: false
         type: string
@@ -56,12 +72,13 @@ jobs:
         os:
           - ubuntu-latest
         ansible-version:
+          - stable-2.15
           - stable-2.16
           - stable-2.17
-          - stable-2.18
           - milestone
           - devel
         python-version:
+          - "3.9"
           - "3.10"
           - "3.11"
           - "3.12"

--- a/.github/workflows/unit_source.yml
+++ b/.github/workflows/unit_source.yml
@@ -16,6 +16,22 @@ on:
         default: >-
           [
             {
+              "ansible-version": "stable-2.16",
+              "python-version": "3.9"
+            },
+            {
+              "ansible-version": "stable-2.17",
+              "python-version": "3.9"
+            },
+            {
+              "ansible-version": "milestone",
+              "python-version": "3.9"
+            },
+            {
+              "ansible-version": "devel",
+              "python-version": "3.9"
+            },
+            {
               "ansible-version": "devel",
               "python-version": "3.10"
             },
@@ -24,9 +40,9 @@ on:
               "python-version": "3.10"
             },
             {
-              "ansible-version": "stable-2.18",
-              "python-version": "3.10"
-            },
+              "ansible-version": "stable-2.15",
+              "python-version": "3.12"
+            }
           ]
         required: false
         type: string
@@ -41,12 +57,13 @@ jobs:
       fail-fast: false
       matrix:
         ansible-version:
+          - stable-2.15
           - stable-2.16
           - stable-2.17
-          - stable-2.18
           - milestone
           - devel
         python-version:
+          - "3.9"
           - "3.10"
           - "3.11"
           - "3.12"


### PR DESCRIPTION
Reverts ansible-network/github_actions#160

Reverting this PR based on https://access.redhat.com/support/policy/updates/ansible-automation-platform

ansible-core 2.15's EOL is December 2025