### PR TITLE
Update a ansible-core and python version to the current state

### DIFF
--- a/.github/workflows/integration_simple.yml
+++ b/.github/workflows/integration_simple.yml
@@ -8,38 +8,68 @@ on:
         type: string
       matrix_exclude:
         # https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html#ansible-core-support-matrix
-        # 2.14 supports Python 3.9-3.11
         # 2.15 supports Python 3.9-3.11
         # 2.16 supports Python 3.10-3.11
-        # https://docs.ansible.com/ansible/devel/roadmap/ROADMAP_2_16.html
-        # milestone is 2.16 until after 2.16 branches from devel
-        # devel is 2.16 until 2023-09-18
+        # 2.17 supports Python 3.10-3.12
+        # 2.18 supports Python 3.11-3.13
+        # support for Python 3.13 added and 3.10 removed in 2.18 for control node
+        # taret node supported Python 3.8-3.13 as of 2.18
+        # milestone is and devel is switched to 2.19
+        # https://docs.ansible.com/ansible/devel/roadmap/ROADMAP_2_18.html
         default: >-
           [
+            {
+              "ansible-version": "devel",
+              "python-version": "3.10"
+            },
+            {
+              "ansible-version": "devel",
+              "python-version": "3.9"
+            },
+            {
+              "ansible-version": "milestone",
+              "python-version": "3.10"
+            },
+            {
+              "ansible-version": "milestone",
+              "python-version": "3.9"
+            },
+            {
+              "ansible-version": "stable-2.18",
+              "python-version": "3.10"
+            },
+            {
+              "ansible-version": "stable-2.18",
+              "python-version": "3.9"
+            },
+            {
+              "ansible-version": "stable-2.17",
+              "python-version": "3.9"
+            },
+            {
+              "ansible-version": "stable-2.17",
+              "python-version": "3.13"
+            },
             {
               "ansible-version": "stable-2.16",
               "python-version": "3.9"
             },
             {
-              "ansible-version": "milestone",
-              "python-version": "3.9"
+              "ansible-version": "stable-2.16",
+              "python-version": "3.12"
             },
             {
-              "ansible-version": "devel",
-              "python-version": "3.9"
-            },
-            {
-              "ansible-version": "devel",
-              "python-version": "3.10"
-            },
-            {
-              "ansible-version": "milestone",
-              "python-version": "3.10"
+              "ansible-version": "stable-2.16",
+              "python-version": "3.13"
             },
             {
               "ansible-version": "stable-2.15",
               "python-version": "3.12"
-             }
+            },
+            {
+              "ansible-version": "stable-2.15",
+              "python-version": "3.13"
+            }
           ]
         required: false
         type: string
@@ -61,16 +91,18 @@ jobs:
       fail-fast: false
       matrix:
         ansible-version:
-          - stable-2.14
           - stable-2.15
           - stable-2.16
+          - stable-2.17
+          - stable-2.18
           - milestone
           - devel
         python-version:
-          # ansible-navigator supports python 3.8+
           - "3.9"
           - "3.10"
           - "3.11"
+          - "3.12"
+          - "3.13"
         exclude: ${{ fromJSON(inputs.matrix_exclude) }}
 
     name: "py${{ matrix.python-version }} / ${{ matrix.ansible-version }}"

--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -9,16 +9,37 @@ on:
       matrix_exclude:
         # https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html#ansible-core-support-matrix
         # 2.15 supports Python 3.9-3.11
-        # 2.16 supports Python 3.10-3.12
+        # 2.16 supports Python 3.10-3.11
         # 2.17 supports Python 3.10-3.12
-        # https://docs.ansible.com/ansible/devel/roadmap/ROADMAP_2_17.html
-        # milestone is 2.17 until after 2.17 branches from devel
-        # devel is 2.17 until 2024-04-01
-        # remove 3.12/milestone from matrix_exclude when milestone is next forwarded
+        # 2.18 supports Python 3.11-3.13
+        # support for Python 3.13 added and 3.10 removed in 2.18 for control node
+        # taret node supported Python 3.8-3.13 as of 2.18
+        # milestone is and devel is switched to 2.19
+        # https://docs.ansible.com/ansible/devel/roadmap/ROADMAP_2_18.html
         default: >-
           [
             {
-              "ansible-version": "stable-2.16",
+              "ansible-version": "devel",
+              "python-version": "3.10"
+            },
+            {
+              "ansible-version": "devel",
+              "python-version": "3.9"
+            },
+            {
+              "ansible-version": "milestone",
+              "python-version": "3.10"
+            },
+            {
+              "ansible-version": "milestone",
+              "python-version": "3.9"
+            },
+            {
+              "ansible-version": "stable-2.18",
+              "python-version": "3.10"
+            },
+            {
+              "ansible-version": "stable-2.18",
               "python-version": "3.9"
             },
             {
@@ -26,24 +47,28 @@ on:
               "python-version": "3.9"
             },
             {
-              "ansible-version": "milestone",
+              "ansible-version": "stable-2.17",
+              "python-version": "3.13"
+            },
+            {
+              "ansible-version": "stable-2.16",
               "python-version": "3.9"
             },
             {
-              "ansible-version": "devel",
-              "python-version": "3.9"
+              "ansible-version": "stable-2.16",
+              "python-version": "3.12"
             },
             {
-              "ansible-version": "devel",
-              "python-version": "3.10"
-            },
-            {
-              "ansible-version": "milestone",
-              "python-version": "3.10"
+              "ansible-version": "stable-2.16",
+              "python-version": "3.13"
             },
             {
               "ansible-version": "stable-2.15",
               "python-version": "3.12"
+            },
+            {
+              "ansible-version": "stable-2.15",
+              "python-version": "3.13"
             }
           ]
         required: false
@@ -75,6 +100,7 @@ jobs:
           - stable-2.15
           - stable-2.16
           - stable-2.17
+          - stable-2.18
           - milestone
           - devel
         python-version:
@@ -82,6 +108,7 @@ jobs:
           - "3.10"
           - "3.11"
           - "3.12"
+          - "3.13"
         exclude: ${{ fromJSON(inputs.matrix_exclude) }}
         include: ${{ fromJSON(inputs.matrix_include) }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/unit_galaxy.yml
+++ b/.github/workflows/unit_galaxy.yml
@@ -10,13 +10,36 @@ on:
         # https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html#ansible-core-support-matrix
         # 2.15 supports Python 3.9-3.11
         # 2.16 supports Python 3.10-3.11
-        # https://docs.ansible.com/ansible/devel/roadmap/ROADMAP_2_16.html
-        # milestone is 2.16 until after 2.16 branches from devel
-        # devel is 2.16 until 2023-09-18
+        # 2.17 supports Python 3.10-3.12
+        # 2.18 supports Python 3.11-3.13
+        # support for Python 3.13 added and 3.10 removed in 2.18 for control node
+        # taret node supported Python 3.8-3.13 as of 2.18
+        # milestone is and devel is switched to 2.19
+        # https://docs.ansible.com/ansible/devel/roadmap/ROADMAP_2_18.html
         default: >-
           [
             {
-              "ansible-version": "stable-2.16",
+              "ansible-version": "devel",
+              "python-version": "3.10"
+            },
+            {
+              "ansible-version": "devel",
+              "python-version": "3.9"
+            },
+            {
+              "ansible-version": "milestone",
+              "python-version": "3.10"
+            },
+            {
+              "ansible-version": "milestone",
+              "python-version": "3.9"
+            },
+            {
+              "ansible-version": "stable-2.18",
+              "python-version": "3.10"
+            },
+            {
+              "ansible-version": "stable-2.18",
               "python-version": "3.9"
             },
             {
@@ -24,25 +47,29 @@ on:
               "python-version": "3.9"
             },
             {
-              "ansible-version": "milestone",
+              "ansible-version": "stable-2.17",
+              "python-version": "3.13"
+            },
+            {
+              "ansible-version": "stable-2.16",
               "python-version": "3.9"
             },
             {
-              "ansible-version": "devel",
-              "python-version": "3.9"
+              "ansible-version": "stable-2.16",
+              "python-version": "3.12"
             },
             {
-              "ansible-version": "devel",
-              "python-version": "3.10"
-            },
-            {
-              "ansible-version": "milestone",
-              "python-version": "3.10"
+              "ansible-version": "stable-2.16",
+              "python-version": "3.13"
             },
             {
               "ansible-version": "stable-2.15",
               "python-version": "3.12"
-             }
+            },
+            {
+              "ansible-version": "stable-2.15",
+              "python-version": "3.13"
+            }
           ]
         required: false
         type: string
@@ -66,12 +93,15 @@ jobs:
           - stable-2.15
           - stable-2.16
           - stable-2.17
+          - stable-2.18
           - milestone
           - devel
         python-version:
           - "3.9"
           - "3.10"
           - "3.11"
+          - "3.12"
+          - "3.13"
         exclude: ${{ fromJSON(inputs.matrix_exclude) }}
         include: ${{ fromJSON(inputs.matrix_include) }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/unit_source.yml
+++ b/.github/workflows/unit_source.yml
@@ -9,14 +9,37 @@ on:
       matrix_exclude:
         # https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html#ansible-core-support-matrix
         # 2.15 supports Python 3.9-3.11
-        # 2.16 supports Python 3.10-3.12
-        # https://docs.ansible.com/ansible/devel/roadmap/ROADMAP_2_17.html
-        # milestone is 2.18
-        # devel is 2.18 until xxxx-xx-xx
+        # 2.16 supports Python 3.10-3.11
+        # 2.17 supports Python 3.10-3.12
+        # 2.18 supports Python 3.11-3.13
+        # support for Python 3.13 added and 3.10 removed in 2.18 for control node
+        # taret node supported Python 3.8-3.13 as of 2.18
+        # milestone is and devel is switched to 2.19
+        # https://docs.ansible.com/ansible/devel/roadmap/ROADMAP_2_18.html
         default: >-
           [
             {
-              "ansible-version": "stable-2.16",
+              "ansible-version": "devel",
+              "python-version": "3.10"
+            },
+            {
+              "ansible-version": "devel",
+              "python-version": "3.9"
+            },
+            {
+              "ansible-version": "milestone",
+              "python-version": "3.10"
+            },
+            {
+              "ansible-version": "milestone",
+              "python-version": "3.9"
+            },
+            {
+              "ansible-version": "stable-2.18",
+              "python-version": "3.10"
+            },
+            {
+              "ansible-version": "stable-2.18",
               "python-version": "3.9"
             },
             {
@@ -24,24 +47,28 @@ on:
               "python-version": "3.9"
             },
             {
-              "ansible-version": "milestone",
+              "ansible-version": "stable-2.17",
+              "python-version": "3.13"
+            },
+            {
+              "ansible-version": "stable-2.16",
               "python-version": "3.9"
             },
             {
-              "ansible-version": "devel",
-              "python-version": "3.9"
+              "ansible-version": "stable-2.16",
+              "python-version": "3.12"
             },
             {
-              "ansible-version": "devel",
-              "python-version": "3.10"
-            },
-            {
-              "ansible-version": "milestone",
-              "python-version": "3.10"
+              "ansible-version": "stable-2.16",
+              "python-version": "3.13"
             },
             {
               "ansible-version": "stable-2.15",
               "python-version": "3.12"
+            },
+            {
+              "ansible-version": "stable-2.15",
+              "python-version": "3.13"
             }
           ]
         required: false
@@ -60,6 +87,7 @@ jobs:
           - stable-2.15
           - stable-2.16
           - stable-2.17
+          - stable-2.18
           - milestone
           - devel
         python-version:
@@ -67,6 +95,7 @@ jobs:
           - "3.10"
           - "3.11"
           - "3.12"
+          - "3.13"
         exclude: ${{ fromJSON(inputs.matrix_exclude) }}
     continue-on-error: ${{ matrix.ansible-version == 'devel' }}
 


### PR DESCRIPTION
Rationale: to keep up with the of lifecycle of the ansible-core and python

- ansible-core 2.18 release is expected in 04 Nov 2014
- ansible-core 2.18 brings support of python 3.13 and removes support of python 3.10
- ansible-core 2.17 released 20 May 2024
- ansible-core 2.14 reach EOL on 20 May 2024
- Python 3.13 was released on 07 Oct 2024
- ansible 2.14 reach EOL on 20 May 2024
- current devel and milestone is switched to 2.19