### PR TITLE
changelog_evaluator - pull checkout ref from PR

### DIFF
--- a/.github/actions/changelog_evaluator/action.yml
+++ b/.github/actions/changelog_evaluator/action.yml
@@ -35,6 +35,8 @@ runs:
   steps:
     - uses: actions/checkout@v2
       id: checkout
+      with:
+        ref: refs/pull/${{ github.event.number }}/merge
     - name: Fetch change types from changelog fragments
       id: evaluate
       shell: bash {0}


### PR DESCRIPTION
Because PRs are usually generated from a fork, we have to use the pull_request_target events rather than the pull_request events.  This means that by default the checkout plugin will checkout main rather than the PR, and our fragments won't be available.