### PR TITLE
Update ansible-lint action in workflow

### DIFF
--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -8,4 +8,4 @@ jobs:
     steps:
       - uses: ansible-network/github_actions/.github/actions/checkout_dependency@main
       - name: Run ansible-lint
-        uses: ansible/ansible-lint-action@main
+        uses: ansible/ansible-lint@main


### PR DESCRIPTION
Fixes #168

Replace the deprecated `ansible/ansible-lint-action@main` with `ansible/ansible-lint@main` in the workflow file `.github/workflows/ansible-lint.yml`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/ansible-network/github_actions/pull/169?shareId=47ab6e73-09b5-4b9d-9d18-05b06ed3fc60).