### PR TITLE
Drop version ansible-core 2.15 and python 3.9

### DIFF
--- a/.github/actions/ansible_aws_test_provider/action.yaml
+++ b/.github/actions/ansible_aws_test_provider/action.yaml
@@ -22,10 +22,10 @@ outputs:
 runs:
   using: composite
   steps:
-    - name: Set up Python '3.9'
+    - name: Set up Python '3.12'
       uses: actions/setup-python@v4
       with:
-        python-version: "3.9"
+        python-version: "3.12"
 
     - name: install python required modules
       run: pip install requests

--- a/.github/actions/ansible_azure_test_provider/action.yaml
+++ b/.github/actions/ansible_azure_test_provider/action.yaml
@@ -22,10 +22,10 @@ outputs:
 runs:
   using: composite
   steps:
-    - name: Set up Python '3.9'
+    - name: Set up Python '3.12'
       uses: actions/setup-python@v4
       with:
-        python-version: "3.9"
+        python-version: "3.12"
 
     - name: install python required modules
       run: pip install requests

--- a/.github/actions/ansible_test_splitter/action.yml
+++ b/.github/actions/ansible_test_splitter/action.yml
@@ -32,7 +32,7 @@ runs:
     - name: setup python
       uses: actions/setup-python@v4
       with:
-        python-version: "3.9"
+        python-version: "3.12"
 
     - name: Install python required libraries
       run: pip install -U pyyaml

--- a/.github/actions/ansible_validate_changelog/action.yml
+++ b/.github/actions/ansible_validate_changelog/action.yml
@@ -23,7 +23,7 @@ runs:
     - name: Setup python
       uses: actions/setup-python@v4
       with:
-        python-version: "3.9"
+        python-version: "3.12"
 
     - name: Install python dependencies
       run: |

--- a/.github/actions/checkout_dependency/action.yml
+++ b/.github/actions/checkout_dependency/action.yml
@@ -15,10 +15,10 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Set up Python '3.9'
+    - name: Set up Python '3.12'
       uses: actions/setup-python@v4
       with:
-        python-version: "3.9"
+        python-version: "3.12"
 
     - name: install PyGithub
       run: |

--- a/.github/actions/commit_to_pullrequest/action.yml
+++ b/.github/actions/commit_to_pullrequest/action.yml
@@ -41,7 +41,7 @@ runs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: "3.9"
+        python-version: "3.12"
 
     - name: Install required python libraries
       run: pip install -U ${{ inputs.python_libs }}

--- a/.github/actions/create_pullrequest/action.yml
+++ b/.github/actions/create_pullrequest/action.yml
@@ -37,7 +37,7 @@ runs:
     - name: setup python
       uses: actions/setup-python@v4
       with:
-        python-version: "3.9"
+        python-version: "3.12"
 
     - name: Install python required libraries
       run: pip install -U pygithub

--- a/.github/workflows/integration_simple.yml
+++ b/.github/workflows/integration_simple.yml
@@ -23,28 +23,12 @@ on:
               "python-version": "3.10"
             },
             {
-              "ansible-version": "devel",
-              "python-version": "3.9"
-            },
-            {
               "ansible-version": "milestone",
               "python-version": "3.10"
             },
             {
-              "ansible-version": "milestone",
-              "python-version": "3.9"
-            },
-            {
               "ansible-version": "stable-2.18",
               "python-version": "3.10"
-            },
-            {
-              "ansible-version": "stable-2.18",
-              "python-version": "3.9"
-            },
-            {
-              "ansible-version": "stable-2.17",
-              "python-version": "3.9"
             },
             {
               "ansible-version": "stable-2.17",
@@ -52,22 +36,10 @@ on:
             },
             {
               "ansible-version": "stable-2.16",
-              "python-version": "3.9"
-            },
-            {
-              "ansible-version": "stable-2.16",
               "python-version": "3.12"
             },
             {
               "ansible-version": "stable-2.16",
-              "python-version": "3.13"
-            },
-            {
-              "ansible-version": "stable-2.15",
-              "python-version": "3.12"
-            },
-            {
-              "ansible-version": "stable-2.15",
               "python-version": "3.13"
             }
           ]
@@ -91,14 +63,17 @@ jobs:
       fail-fast: false
       matrix:
         ansible-version:
-          - stable-2.15
+          # ansible-core 2.15 reached EOL on November 2024
+          # ansible-core 2.16 will reach EOL on May 2025
           - stable-2.16
           - stable-2.17
           - stable-2.18
           - milestone
           - devel
         python-version:
-          - "3.9"
+          # 2.16 supports Python 3.10-3.11
+          # 2.17 supports Python 3.10-3.12
+          # 2.18 supports Python 3.11-3.13
           - "3.10"
           - "3.11"
           - "3.12"

--- a/.github/workflows/release-branch.yml
+++ b/.github/workflows/release-branch.yml
@@ -50,7 +50,7 @@ jobs:
       - name: setup python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.9"
+          python-version: "3.12"
 
       - name: Install required python modules
         run: pip3 install tox yq

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -38,7 +38,7 @@ jobs:
       - name: setup python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.9"
+          python-version: "3.12"
 
       - name: install python libraries
         run: pip3 install yq pygithub

--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -23,36 +23,16 @@ on:
               "python-version": "3.10"
             },
             {
-              "ansible-version": "devel",
-              "python-version": "3.9"
-            },
-            {
               "ansible-version": "milestone",
               "python-version": "3.10"
             },
             {
-              "ansible-version": "milestone",
-              "python-version": "3.9"
-            },
-            {
               "ansible-version": "stable-2.18",
               "python-version": "3.10"
-            },
-            {
-              "ansible-version": "stable-2.18",
-              "python-version": "3.9"
-            },
-            {
-              "ansible-version": "stable-2.17",
-              "python-version": "3.9"
             },
             {
               "ansible-version": "stable-2.17",
               "python-version": "3.13"
-            },
-            {
-              "ansible-version": "stable-2.16",
-              "python-version": "3.9"
             },
             {
               "ansible-version": "stable-2.16",
@@ -97,14 +77,16 @@ jobs:
         os:
           - ubuntu-latest
         ansible-version:
-          - stable-2.15
+          # ansible-core 2.15 reached EOL on November 2024
           - stable-2.16
           - stable-2.17
           - stable-2.18
           - milestone
           - devel
         python-version:
-          - "3.9"
+          # 2.16 supports Python 3.10-3.11
+          # 2.17 supports Python 3.10-3.12
+          # 2.18 supports Python 3.11-3.13
           - "3.10"
           - "3.11"
           - "3.12"

--- a/.github/workflows/unit_galaxy.yml
+++ b/.github/workflows/unit_galaxy.yml
@@ -23,36 +23,16 @@ on:
               "python-version": "3.10"
             },
             {
-              "ansible-version": "devel",
-              "python-version": "3.9"
-            },
-            {
               "ansible-version": "milestone",
               "python-version": "3.10"
             },
             {
-              "ansible-version": "milestone",
-              "python-version": "3.9"
-            },
-            {
               "ansible-version": "stable-2.18",
               "python-version": "3.10"
-            },
-            {
-              "ansible-version": "stable-2.18",
-              "python-version": "3.9"
-            },
-            {
-              "ansible-version": "stable-2.17",
-              "python-version": "3.9"
             },
             {
               "ansible-version": "stable-2.17",
               "python-version": "3.13"
-            },
-            {
-              "ansible-version": "stable-2.16",
-              "python-version": "3.9"
             },
             {
               "ansible-version": "stable-2.16",
@@ -90,14 +70,16 @@ jobs:
         os:
           - ubuntu-latest
         ansible-version:
-          - stable-2.15
+          # ansible-core 2.15 reached EOL on November 2024
           - stable-2.16
           - stable-2.17
           - stable-2.18
           - milestone
           - devel
         python-version:
-          - "3.9"
+          # 2.16 supports Python 3.10-3.11
+          # 2.17 supports Python 3.10-3.12
+          # 2.18 supports Python 3.11-3.13
           - "3.10"
           - "3.11"
           - "3.12"

--- a/.github/workflows/unit_source.yml
+++ b/.github/workflows/unit_source.yml
@@ -23,36 +23,16 @@ on:
               "python-version": "3.10"
             },
             {
-              "ansible-version": "devel",
-              "python-version": "3.9"
-            },
-            {
               "ansible-version": "milestone",
               "python-version": "3.10"
             },
             {
-              "ansible-version": "milestone",
-              "python-version": "3.9"
-            },
-            {
               "ansible-version": "stable-2.18",
               "python-version": "3.10"
-            },
-            {
-              "ansible-version": "stable-2.18",
-              "python-version": "3.9"
-            },
-            {
-              "ansible-version": "stable-2.17",
-              "python-version": "3.9"
             },
             {
               "ansible-version": "stable-2.17",
               "python-version": "3.13"
-            },
-            {
-              "ansible-version": "stable-2.16",
-              "python-version": "3.9"
             },
             {
               "ansible-version": "stable-2.16",
@@ -84,14 +64,16 @@ jobs:
       fail-fast: false
       matrix:
         ansible-version:
-          - stable-2.15
+          # ansible-core 2.15 reached EOL on November 2024
           - stable-2.16
           - stable-2.17
           - stable-2.18
           - milestone
           - devel
         python-version:
-          - "3.9"
+          # 2.16 supports Python 3.10-3.11
+          # 2.17 supports Python 3.10-3.12
+          # 2.18 supports Python 3.11-3.13
           - "3.10"
           - "3.11"
           - "3.12"


### PR DESCRIPTION
Closes #170

Reason:

- ansible-core 2.15 reached EOL in Nov 2024
- support of python 3.9 dropped in ansible-core 2.16

Ref:
- https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html#ansible-core-support-matrix