### PR TITLE
Bugfix: add stable-2.19 to matrix

### DIFF
--- a/.github/workflows/integration_simple.yml
+++ b/.github/workflows/integration_simple.yml
@@ -12,9 +12,10 @@ on:
         # 2.16 supports Python 3.10-3.11
         # 2.17 supports Python 3.10-3.12
         # 2.18 supports Python 3.11-3.13
+        # 2.19 supports Python 3.11-3.13
         # support for Python 3.13 added and 3.10 removed in 2.18 for control node
-        # taret node supported Python 3.8-3.13 as of 2.18
-        # milestone is and devel is switched to 2.19
+        # taret node supported Python 3.8-3.13 as of 2.18 and 2.19
+        # milestone is and devel is switched to 2.20
         # https://docs.ansible.com/ansible/devel/roadmap/ROADMAP_2_18.html
         default: >-
           [
@@ -24,6 +25,10 @@ on:
             },
             {
               "ansible-version": "milestone",
+              "python-version": "3.10"
+            },
+            {
+              "ansible-version": "stable-2.19",
               "python-version": "3.10"
             },
             {
@@ -68,6 +73,7 @@ jobs:
           - stable-2.16
           - stable-2.17
           - stable-2.18
+          - stable-2.19
           - milestone
           - devel
         python-version:

--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -12,10 +12,11 @@ on:
         # 2.16 supports Python 3.10-3.11
         # 2.17 supports Python 3.10-3.12
         # 2.18 supports Python 3.11-3.13
+        # 2.19 supports Python 3.11-3.13
         # support for Python 3.13 added and 3.10 removed in 2.18 for control node
-        # taret node supported Python 3.8-3.13 as of 2.18
-        # milestone is and devel is switched to 2.19
-        # https://docs.ansible.com/ansible/devel/roadmap/ROADMAP_2_18.html
+        # taret node supported Python 3.8-3.13 as of 2.18 and 2.19
+        # milestone is and devel is switched to 2.20
+        # https://docs.ansible.com/ansible/devel/roadmap/ROADMAP_2_19.html
         default: >-
           [
             {
@@ -24,6 +25,10 @@ on:
             },
             {
               "ansible-version": "milestone",
+              "python-version": "3.10"
+            },
+            {
+              "ansible-version": "stable-2.19",
               "python-version": "3.10"
             },
             {
@@ -81,12 +86,14 @@ jobs:
           - stable-2.16
           - stable-2.17
           - stable-2.18
+          - stable-2.19
           - milestone
           - devel
         python-version:
           # 2.16 supports Python 3.10-3.11
           # 2.17 supports Python 3.10-3.12
           # 2.18 supports Python 3.11-3.13
+          # 2.19 supports Python 3.11-3.13
           - "3.10"
           - "3.11"
           - "3.12"

--- a/.github/workflows/unit_galaxy.yml
+++ b/.github/workflows/unit_galaxy.yml
@@ -12,10 +12,11 @@ on:
         # 2.16 supports Python 3.10-3.11
         # 2.17 supports Python 3.10-3.12
         # 2.18 supports Python 3.11-3.13
+        # 2.19 supports Python 3.11-3.13
         # support for Python 3.13 added and 3.10 removed in 2.18 for control node
-        # taret node supported Python 3.8-3.13 as of 2.18
-        # milestone is and devel is switched to 2.19
-        # https://docs.ansible.com/ansible/devel/roadmap/ROADMAP_2_18.html
+        # taret node supported Python 3.8-3.13 as of 2.18 and 2.19
+        # milestone is and devel is switched to 2.20
+        # https://docs.ansible.com/ansible/devel/roadmap/ROADMAP_2_19.html
         default: >-
           [
             {
@@ -24,6 +25,10 @@ on:
             },
             {
               "ansible-version": "milestone",
+              "python-version": "3.10"
+            },
+            {
+              "ansible-version": "stable-2.19",
               "python-version": "3.10"
             },
             {
@@ -74,6 +79,7 @@ jobs:
           - stable-2.16
           - stable-2.17
           - stable-2.18
+          - stable-2.19
           - milestone
           - devel
         python-version:

--- a/.github/workflows/unit_source.yml
+++ b/.github/workflows/unit_source.yml
@@ -12,9 +12,10 @@ on:
         # 2.16 supports Python 3.10-3.11
         # 2.17 supports Python 3.10-3.12
         # 2.18 supports Python 3.11-3.13
+        # 2.19 supports Python 3.11-3.13
         # support for Python 3.13 added and 3.10 removed in 2.18 for control node
-        # taret node supported Python 3.8-3.13 as of 2.18
-        # milestone is and devel is switched to 2.19
+        # taret node supported Python 3.8-3.13 as of 2.18 and 2.19
+        # milestone is and devel is switched to 2.29
         # https://docs.ansible.com/ansible/devel/roadmap/ROADMAP_2_18.html
         default: >-
           [
@@ -24,6 +25,10 @@ on:
             },
             {
               "ansible-version": "milestone",
+              "python-version": "3.10"
+            },
+            {
+              "ansible-version": "stable-2.19",
               "python-version": "3.10"
             },
             {
@@ -68,6 +73,7 @@ jobs:
           - stable-2.16
           - stable-2.17
           - stable-2.18
+          - stable-2.19
           - milestone
           - devel
         python-version:


### PR DESCRIPTION
As branch `stable-2.19` created the version of mailstone and develop become 2.20 and sanity and integration test become failing. 

Addressed #172 