### PR TITLE
Update matrix to drop python 3.11 for ansible 2.20

### DIFF
--- a/.github/workflows/integration_simple.yml
+++ b/.github/workflows/integration_simple.yml
@@ -15,13 +15,21 @@ on:
         # 2.19 supports Python 3.11-3.13
         # support for Python 3.13 added and 3.10 removed in 2.18 for control node
         # target node supported Python 3.8-3.13 as of 2.18 and 2.19
-        # milestone is and devel is switched to 2.20
+        # milestone is and devel is switched to 2.20 and drops support for Python 3.11
         # https://docs.ansible.com/ansible/devel/roadmap/ROADMAP_2_18.html
         default: >-
           [
             {
               "ansible-version": "devel",
+              "python-version": "3.11"
+            },
+            {
+              "ansible-version": "devel",
               "python-version": "3.10"
+            },
+            {
+              "ansible-version": "milestone",
+              "python-version": "3.11"
             },
             {
               "ansible-version": "milestone",

--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -15,13 +15,21 @@ on:
         # 2.19 supports Python 3.11-3.13
         # support for Python 3.13 added and 3.10 removed in 2.18 for control node
         # target node supported Python 3.8-3.13 as of 2.18 and 2.19
-        # milestone is and devel is switched to 2.20
+        # milestone is and devel is switched to 2.20 and drops support for Python 3.11
         # https://docs.ansible.com/ansible/devel/roadmap/ROADMAP_2_19.html
         default: >-
           [
             {
               "ansible-version": "devel",
+              "python-version": "3.11"
+            },
+            {
+              "ansible-version": "devel",
               "python-version": "3.10"
+            },
+            {
+              "ansible-version": "milestone",
+              "python-version": "3.11"
             },
             {
               "ansible-version": "milestone",

--- a/.github/workflows/unit_galaxy.yml
+++ b/.github/workflows/unit_galaxy.yml
@@ -15,13 +15,21 @@ on:
         # 2.19 supports Python 3.11-3.13
         # support for Python 3.13 added and 3.10 removed in 2.18 for control node
         # target node supported Python 3.8-3.13 as of 2.18 and 2.19
-        # milestone is and devel is switched to 2.20
+        # milestone is and devel is switched to 2.20 and drops support for Python 3.11
         # https://docs.ansible.com/ansible/devel/roadmap/ROADMAP_2_19.html
         default: >-
           [
             {
               "ansible-version": "devel",
+              "python-version": "3.11"
+            },
+            {
+              "ansible-version": "devel",
               "python-version": "3.10"
+            },
+            {
+              "ansible-version": "milestone",
+              "python-version": "3.11"
             },
             {
               "ansible-version": "milestone",

--- a/.github/workflows/unit_source.yml
+++ b/.github/workflows/unit_source.yml
@@ -15,10 +15,14 @@ on:
         # 2.19 supports Python 3.11-3.13
         # support for Python 3.13 added and 3.10 removed in 2.18 for control node
         # target node supported Python 3.8-3.13 as of 2.18 and 2.19
-        # milestone is and devel is switched to 2.29
+        # milestone is and devel is switched to 2.20 and drops support for Python 3.11
         # https://docs.ansible.com/ansible/devel/roadmap/ROADMAP_2_18.html
         default: >-
           [
+            {
+              "ansible-version": "milestone",
+              "python-version": "3.11"
+            },
             {
               "ansible-version": "devel",
               "python-version": "3.11"


### PR DESCRIPTION
 ansible drops support of python 3.11 in 2.20
 ref: https://github.com/ansible/ansible/pull/85590

Closes #176 