### PR TITLE
ansible-test-splitter minor fix

### DIFF
--- a/.github/actions/ansible_test_splitter/list_changed_common.py
+++ b/.github/actions/ansible_test_splitter/list_changed_common.py
@@ -396,7 +396,7 @@ class Collection:
             yield Target(alias)
 
     def is_candidate_target(self, target: Target) -> bool:
-        """Return true if the target is not ignored and not not already part of the test plan.
+        """Return true if the target is not ignored and not already part of the test plan.
 
         :param target: target name being checked
         :returns: Whether the target should be added to the test plan.

--- a/.github/actions/ansible_test_splitter/list_changed_common.py
+++ b/.github/actions/ansible_test_splitter/list_changed_common.py
@@ -281,9 +281,15 @@ class Target:
 
         :param target_path: path to the target
         """
-        self.path = target_path
-        self.lines = [line.split("#")[0] for line in target_path.read_text().split("\n") if line]
-        self.name = target_path.parent.name
+        self.name = target_path.stem
+        self.lines = []
+        aliases_path = PosixPath(target_path / "aliases")
+        if aliases_path.exists():
+            self.lines = [
+                line.split("#")[0]
+                for line in aliases_path.read_text(encoding="utf-8").split("\n")
+                if line
+            ]
         self.exec_time = 0
 
     def is_alias_of(self, name: str) -> bool:
@@ -386,40 +392,45 @@ class Collection:
 
         :yields: a collection target
         """
-        for alias in self.collection_path.glob("tests/integration/targets/*/aliases"):
+        for alias in self.collection_path.glob("tests/integration/targets/*"):
             yield Target(alias)
 
-    def _is_target_already_added(self, target_name: str) -> bool:
-        """Return true if the target is already part of the test plan.
+    def is_candidate_target(self, target: Target) -> bool:
+        """Return true if the target is not ignored and not not already part of the test plan.
 
-        :param target_name: target name being checked
-        :returns: whether the target is already part of the test plan or not
+        :param target: target name being checked
+        :returns: Whether the target should be added to the test plan.
         """
-        for target_src in self._my_test_plan:
-            if target_src.is_alias_of(target_name):
-                return True
-        return False
+        return not target.is_ignored() and not any(
+            target.name == t.name for t in self._my_test_plan
+        )
 
-    def add_target_to_plan(self, target_name: str, is_direct: bool = True) -> None:
+    def add_target_to_plan(self, target_name: str) -> None:
         """Add specific target to the test plan.
 
         :param target_name: target name being added
-        :param is_direct: whether it is a direct target or an alias
         """
-        if not self._is_target_already_added(target_name):
-            for plan_target in self.targets():
-                if plan_target.is_disabled():
-                    continue
-                # For indirect targets we want to skip "ignored" tests
-                if not is_direct and plan_target.is_ignored():
-                    continue
-                if plan_target.is_alias_of(target_name):
-                    self._my_test_plan.append(plan_target)
+        # add the integration test target to the plan
+        for t in self.targets():
+            if t.name == target_name:
+                print(f"...target = {target_name} - is_candidate = {self.is_candidate_target(t)}")
+                if self.is_candidate_target(t):
+                    self._my_test_plan.append(t)
+                return
+
+        # Trying to impacted target for modified role, lookup, inventory, modules...
+        if target_name.startswith("modules_"):
+            target_name = target_name.split("_", maxsplit=1)[1]
+        # add all the targets with the exact name matching the target name or having
+        # the target name in their aliases
+        for t in self.targets():
+            if t.is_alias_of(target_name) and self.is_candidate_target(t):
+                self._my_test_plan.append(t)
 
     def cover_all(self) -> None:
         """Cover all the targets available."""
         for cover_target in self.targets():
-            self.add_target_to_plan(cover_target.name, is_direct=False)
+            self.add_target_to_plan(cover_target.name)
 
     def cover_module_utils(self, pymodule: str, names: list[str]) -> None:
         """Track the targets to run follow up to a module_utils changed.
@@ -440,7 +451,7 @@ class Collection:
 
         for mod, mod_imports in self.modules_import.items():
             if any(util in mod_imports for util in u_candidates):
-                self.add_target_to_plan(mod, is_direct=False)
+                self.add_target_to_plan(mod)
 
     def slow_targets_to_test(self) -> list[str]:
         """List collection slow targets.

--- a/.github/actions/ansible_test_splitter/list_changed_targets.py
+++ b/.github/actions/ansible_test_splitter/list_changed_targets.py
@@ -74,9 +74,6 @@ class ListChangedTargets:
         ) -> None:
             if plugin_type == "targets":
                 file_name, plugin_file_name = str(ref_path), str(ref_path)
-            elif plugin_type == "modules":
-                file_name = PosixPath(ref_path).stem
-                plugin_file_name = file_name
             elif plugin_type == "roles":
                 file_name = str(ref_path)
                 plugin_file_name = f"role/{ref_path}"
@@ -119,6 +116,12 @@ class ListChangedTargets:
                 _add_changed_target(whc.collection_name, target, "targets")
             for role in whc.roles():
                 _add_changed_target(whc.collection_name, role, "roles")
+
+        print("----------- Test plan      -----------")
+        for collection in collections:
+            print(
+                collection.collection_name, " -> ", json.dumps(collection.test_plan_names, indent=2)
+            )
 
         print("----------- Listed Changes -----------\n", json.dumps(listed_changes, indent=2))
         return {x: make_unique(y["targets"]) for x, y in listed_changes.items()}

--- a/.github/actions/ansible_test_splitter/test_list_changed_targets.py
+++ b/.github/actions/ansible_test_splitter/test_list_changed_targets.py
@@ -147,44 +147,56 @@ def build_collection(aliases: list[Any]) -> Collection:
         return mycollection
 
 
-def build_alias(name: str, text: str) -> MagicMock:
-    """Build target alias.
+def create_test_content(path: PosixPath, aliases: str = "") -> PosixPath:
+    """Create integration test target.
 
-    :param name: collection name
-    :param text: alias file content
-    :returns: Mock target
+    :param path: The path to the target
+    :param aliases: the content of the aliases file
+    :returns: the path to the target.
     """
-    m_alias_file = MagicMock()
-    m_alias_file.read_text.return_value = text
-    m_alias_file.parent.name = name
-    return m_alias_file
+    path.mkdir()
+    if aliases:
+        file = path / "aliases"
+        file.write_text(aliases)
+    return path
 
 
-def test_c_targets() -> None:
-    """Test add targets method from Collection class."""
+def test_c_targets(tmp_path: PosixPath) -> None:
+    """Test add targets method from Collection class.
+
+    :param tmp_path: python temporary path fixture
+    """
     mycollection = build_collection([])
     assert not list(mycollection.targets())
 
-    mycollection = build_collection([build_alias("a", "ec2\n")])
+    a = tmp_path / "a"
+    mycollection = build_collection([create_test_content(a, "ec2\n")])
     assert len(list(mycollection.targets())) == 1
     assert list(mycollection.targets())[0].name == "a"
     assert list(mycollection.targets())[0].is_alias_of("ec2")
 
-    mycollection = build_collection([build_alias("a", "#ec2\n")])
+    b = tmp_path / "b"
+    mycollection = build_collection([create_test_content(b, "#ec2\n")])
     assert len(list(mycollection.targets())) == 1
-    assert list(mycollection.targets())[0].name == "a"
+    assert list(mycollection.targets())[0].name == "b"
     assert list(mycollection.targets())[0].execution_time() == 180
 
-    mycollection = build_collection([build_alias("a", "time=30\n")])
+    c = tmp_path / "c"
+    mycollection = build_collection([create_test_content(c, "time=30\n")])
     assert len(list(mycollection.targets())) == 1
-    assert list(mycollection.targets())[0].name == "a"
+    assert list(mycollection.targets())[0].name == "c"
     assert list(mycollection.targets())[0].execution_time() == 30
 
 
-def test_2_targets_for_one_module() -> None:
-    """Test 2 targets."""
+def test_2_targets_for_one_module(tmp_path: PosixPath) -> None:
+    """Test 2 targets.
+
+    :param tmp_path: python temporary path fixture
+    """
+    a = tmp_path / "a"
+    b = tmp_path / "b"
     collection = build_collection(
-        [build_alias("a", "ec2_instance\n"), build_alias("b", "ec2_instance\n")]
+        [create_test_content(a, "ec2_instance\n"), create_test_content(b, "ec2_instance\n")]
     )
     assert collection.regular_targets_to_test() == []
     collection.add_target_to_plan("ec2_instance")
@@ -192,45 +204,42 @@ def test_2_targets_for_one_module() -> None:
 
 
 @patch("list_changed_common.read_collection_name")
-def test_c_disabled_unstable(m_read_collection_name: MagicMock) -> None:
+def test_c_disabled_unstable(tmp_path: PosixPath) -> None:
     """Test disable/unstable targets.
 
-    :param m_read_collection_name: read_collection_name patched method
+    :param tmp_path: python temporary path fixture
     """
-    m_read_collection_name.return_value = "some.collection"
-    collection = Collection(PosixPath("nowhere"))
-    m_c_path = MagicMock()
-    collection.collection_path = m_c_path
-    m_c_path.glob.return_value = [
-        build_alias("a", "disabled\n"),
-        build_alias("b", "unstable\n"),
-    ]
+    a = tmp_path / "a"
+    b = tmp_path / "b"
+    collection = build_collection(
+        [create_test_content(a, "disabled\n"), create_test_content(b, "unstable\n")]
+    )
+    collection.collection_path = tmp_path
 
     # all, we should ignore the disabled,unstable jobs
     collection.cover_all()
     assert len(collection.regular_targets_to_test()) == 0
     # if the module is targets, we continue to ignore the disabled
-    collection.add_target_to_plan("a")
+    collection.add_target_to_plan("modules_a")
     assert len(collection.regular_targets_to_test()) == 0
-    # unstable targets should not be triggered if they were pulled in as a dependency
-    collection.add_target_to_plan("b", is_direct=False)
+    collection.add_target_to_plan("modules_b")
     assert len(collection.regular_targets_to_test()) == 0
-    # but the unstable is ok when directly triggered
-    collection.add_target_to_plan("b")
-    assert len(collection.regular_targets_to_test()) == 1
 
 
 @patch("list_changed_common.read_collection_name")
-def test_c_slow_regular_targets(m_read_collection_name: MagicMock) -> None:
+def test_c_slow_regular_targets(m_read_collection_name: MagicMock, tmp_path: PosixPath) -> None:
     """Test targets* methods from Collection class.
 
     :param m_read_collection_name: read_collection_name patched method
+    :param tmp_path: python temporary path fixture
     """
     m_read_collection_name.return_value = "some.collection"
+    tortue = tmp_path / "inventory_tortue"
+    lapin = tmp_path / "lapin"
     collection = build_collection(
         [
-            build_alias("tortue", "slow\nec2\n#s3\n"),
-            build_alias("lapin", "notslow\ncarrot\n\n"),
+            create_test_content(tortue, "slow\nec2\n#s3\n"),
+            create_test_content(lapin, "notslow\ncarrot\n\n"),
         ]
     )
 
@@ -241,12 +250,17 @@ def test_c_slow_regular_targets(m_read_collection_name: MagicMock) -> None:
     assert len(collection.slow_targets_to_test()) == 1
 
 
-def test_c_inventory_targets() -> None:
-    """Test targets methods from Collection class."""
+def test_c_inventory_targets(tmp_path: PosixPath) -> None:
+    """Test targets methods from Collection class.
+
+    :param tmp_path: python temporary path fixture
+    """
+    inventory_tortue = tmp_path / "inventory_tortue"
+    lapin = tmp_path / "lapin"
     col = build_collection(
         [
-            build_alias("inventory_tortue", "slow\nec2\n#s3\n"),
-            build_alias("lapin", "notslow\ninventory_carrot\n\n"),
+            create_test_content(inventory_tortue, "slow\nec2\n#s3\n"),
+            create_test_content(lapin, "notslow\ninventory_carrot\n\n"),
         ]
     )
     col.cover_all()
@@ -257,34 +271,45 @@ def test_c_inventory_targets() -> None:
 
 
 @patch("list_changed_common.read_collection_name")
-def test_c_with_cover(m_read_collection_name: MagicMock) -> None:
+def test_c_with_cover(m_read_collection_name: MagicMock, tmp_path: PosixPath) -> None:
     """Test add_target_to_plan method from Collection class.
 
     :param m_read_collection_name: read_collection_name patched method
+    :param tmp_path: python temporary path fixture
     """
     m_read_collection_name.return_value = "some.collection"
     collection = Collection(PosixPath("nowhere"))
     m_c_path = MagicMock()
     collection.collection_path = m_c_path
 
+    tortue = tmp_path / "tortue"
+    lapin = tmp_path / "lapin"
     m_c_path.glob.return_value = [
-        build_alias("tortue", "slow\nec2\n#s3\n"),
-        build_alias("lapin", "carrot\n\n"),
+        create_test_content(tortue, "slow\nec2\n#s3\n"),
+        create_test_content(lapin, "carrot\n\n"),
     ]
     collection.add_target_to_plan("ec2")
     assert len(collection.slow_targets_to_test()) == 1
     assert collection.regular_targets_to_test() == []
 
 
-def test_splitter_with_time() -> None:
-    """Test splitter method from class ElGrandeSeparator."""
+def test_splitter_with_time(tmp_path: PosixPath) -> None:
+    """Test splitter method from class ElGrandeSeparator.
+
+    :param tmp_path: python temporary path fixture
+    """
+    a = tmp_path / "a"
+    b = tmp_path / "b"
+    c = tmp_path / "c"
+    d = tmp_path / "d"
+    e = tmp_path / "e"
     collection_1 = build_collection(
         [
-            build_alias("a", "time=50m\n"),
-            build_alias("b", "time=10m\n"),
-            build_alias("c", "time=180\n"),
-            build_alias("d", "time=140s  \n"),
-            build_alias("e", "time=70\n"),
+            create_test_content(a, "time=50m\n"),
+            create_test_content(b, "time=10m\n"),
+            create_test_content(c, "time=180\n"),
+            create_test_content(d, "time=140s  \n"),
+            create_test_content(e, "time=70\n"),
         ]
     )
     collection_1.cover_all()
@@ -295,18 +320,22 @@ def test_splitter_with_time() -> None:
         ("slot1", ["b", "c", "d", "e"]),
     ]
 
+    a0 = tmp_path / "a0"
+    b0 = tmp_path / "b0"
+    c0 = tmp_path / "c0"
+    d0 = tmp_path / "d0"
     collection_2 = build_collection(
         [
-            build_alias("a", "time=50m\n"),
-            build_alias("b", "time=50m\n"),
-            build_alias("c", "time=18\n"),
-            build_alias("d", "time=5m\n"),
+            create_test_content(a0, "time=50m\n"),
+            create_test_content(b0, "time=50m\n"),
+            create_test_content(c0, "time=18\n"),
+            create_test_content(d0, "time=5m\n"),
         ]
     )
     collection_2.cover_all()
     egs = ElGrandeSeparator([collection_2], ANY)
     result = list(egs.build_up_batches([f"slot{i}" for i in range(3)], collection_2))
-    assert result == [("slot0", ["a"]), ("slot1", ["b"]), ("slot2", ["d", "c"])]
+    assert result == [("slot0", ["a0"]), ("slot1", ["b0"]), ("slot2", ["d0", "c0"])]
 
 
 @patch("list_changed_common.read_collection_name")


### PR DESCRIPTION
ansible-test-splitter was previously reporting incorrect behavior regarding the processing of the aliases file. This fix introduces several corrections to ensure test targets are triggered accurately based on the following logic:

1. Module and Role Aliases
Aliases should map directly to module or role names.

- If an integration test (e.g., Target A) lists Module M or Role R in its aliases, Target A must be triggered whenever M or R is modified.

- Important: A modification to a test target itself does not trigger other targets that share its name as an alias. For example, if Test Target A is modified, it does not automatically trigger all other targets that list "A" in their aliases file.

2. Plugin and Supplemental File Modifications
When files other than a module, role, or test target are modified (e.g., a lookup plugin at lookup/L), the splitter will now identify and trigger all targets that meet either of the following criteria:

- The target name is prefixed with the plugin type and name (e.g., lookup_L).

- The lookup_L identifier is explicitly listed in the target's aliases file.