### PR TITLE
Update collection installation path

### DIFF
--- a/.github/actions/build_install_collection/action.yml
+++ b/.github/actions/build_install_collection/action.yml
@@ -73,7 +73,7 @@ runs:
 
     - name: identify collection (final installation path and tarball name)
       id: identify
-      uses: ansible-network/github_actions/.github/actions/identify_collection@main
+      uses: ./.github/actions/identify_collection
       with:
         source_path: ${{ inputs.source_path }}
       if: ${{ (inputs.collection_path == '') || (inputs.tar_file == '') }}
@@ -84,13 +84,13 @@ runs:
       working-directory: ${{ inputs.source_path }}
 
     - name: Install collection and dependencies (with --pre flag)
-      run: ansible-galaxy collection install ./${{ steps.identify.outputs.tar_file || inputs.tar_file }} --pre -p /home/runner/collections
+      run: ansible-galaxy collection install ./${{ steps.identify.outputs.tar_file || inputs.tar_file }} --pre -p /home/runner/.ansible/collections
       shell: bash
       working-directory: ${{ inputs.source_path }}
       if: ${{ inputs.ansible_version != 'stable-2.9' }}
 
     - name: Install collection and dependencies (without --pre flag)
-      run: ansible-galaxy collection install ./${{ steps.identify.outputs.tar_file || inputs.tar_file }} -p /home/runner/collections
+      run: ansible-galaxy collection install ./${{ steps.identify.outputs.tar_file || inputs.tar_file }} -p /home/runner/.ansible/collections
       shell: bash
       working-directory: ${{ inputs.source_path }}
       if: ${{ inputs.ansible_version == 'stable-2.9' }}

--- a/.github/actions/build_install_collection/action.yml
+++ b/.github/actions/build_install_collection/action.yml
@@ -73,7 +73,7 @@ runs:
 
     - name: identify collection (final installation path and tarball name)
       id: identify
-      uses: ./.github/actions/identify_collection
+      uses: abikouo/github_actions/.github/actions/identify_collection@build_install_031926
       with:
         source_path: ${{ inputs.source_path }}
       if: ${{ (inputs.collection_path == '') || (inputs.tar_file == '') }}

--- a/.github/actions/build_install_collection/action.yml
+++ b/.github/actions/build_install_collection/action.yml
@@ -73,7 +73,7 @@ runs:
 
     - name: identify collection (final installation path and tarball name)
       id: identify
-      uses: abikouo/github_actions/.github/actions/identify_collection@build_install_031926
+      uses: ansible-network/github_actions/.github/actions/identify_collection@main
       with:
         source_path: ${{ inputs.source_path }}
       if: ${{ (inputs.collection_path == '') || (inputs.tar_file == '') }}

--- a/.github/actions/identify_collection/action.yml
+++ b/.github/actions/identify_collection/action.yml
@@ -11,7 +11,7 @@ outputs:
     value: ${{ steps.keys.outputs.namespace }}-${{ steps.keys.outputs.name }}-${{ steps.keys.outputs.version }}.tar.gz
   collection_path:
     description: The final collection path
-    value: /home/runner/collections/ansible_collections/${{ steps.keys.outputs.namespace }}/${{ steps.keys.outputs.name }}
+    value: /home/runner/.ansible/collections/ansible_collections/${{ steps.keys.outputs.namespace }}/${{ steps.keys.outputs.name }}
   dependency:
     description: The collection dependency
     value: ${{ steps.keys.outputs.dependency }}


### PR DESCRIPTION
When installing collection into path `/home/runner/collections`, ansible-galaxy complains with the following error

```
Warning: : The specified collections path '/home/runner/collections' is not part of the configured Ansible collections paths '/home/runner/.ansible/collections:/usr/share/ansible/collections'. The installed collection will not be picked up in an Ansible run, unless within a playbook-adjacent collections directory.
```

We fix this by installing into the path `/home/runner/.ansible/collections`