### PR TITLE
Update ansible test splitter with indirect node count targets

### DIFF
--- a/.github/actions/ansible_test_splitter/README.md
+++ b/.github/actions/ansible_test_splitter/README.md
@@ -76,6 +76,26 @@ _Example_:
 
 For any change on `plugins/lookup/random.py`, this action will produce `lookup_random` and `test_random` as impacted targets.
 
+## Relationship between extensions and targets
+
+This action reads elements to test from `extensions` directory and corresponding tests from `tests/integration/targets` directory. Here after more details on the relationship between extensions and integration tests targets:
+
+- `audit`, the test target name should have prefix `node_query_` or defines the `indirect_node_count` line into the `aliases` file, when `event_query.yml` file changed.
+
+_Example_:
+
+```
+    |___extensions/audit/event_query.yml
+    |___tests
+        |___integration
+            |___targets
+                |___node_query_database_cluster
+                |___query_instance_ec2
+                    |___aliases (contains this line indirect_node_count)
+```
+
+For any change on `extensions/audit/event_query.yml` file, this action will produce `node_query_database_cluster` and `query_instance_ec2` as impacted targets.
+
 ## Debugging
 
 - Set the label `test-all-the-targets` on the pull request to run the full test suite instead of the impacted changes.

--- a/.github/actions/ansible_test_splitter/README.md
+++ b/.github/actions/ansible_test_splitter/README.md
@@ -78,9 +78,9 @@ For any change on `plugins/lookup/random.py`, this action will produce `lookup_r
 
 ## Relationship between extensions and targets
 
-This action reads elements to test from `extensions` directory and corresponding tests from `tests/integration/targets` directory. Here after more details on the relationship between extensions and integration tests targets:
+This action reads elements to test from the `extensions` directory and corresponding tests from the `tests/integration/targets` directory. Here are more details on the relationship between extensions and integration tests targets:
 
-- `audit`, the test target name should have prefix `node_query_` or defines the `indirect_node_count` line into the `aliases` file, when `event_query.yml` file changed.
+- `audit`, the test target name should have a prefix `node_query_` or defines the `indirect_node_count` line in the `aliases` file, when the `event_query.yml` file changed.
 
 _Example_:
 

--- a/.github/actions/ansible_test_splitter/list_changed_common.py
+++ b/.github/actions/ansible_test_splitter/list_changed_common.py
@@ -439,7 +439,7 @@ class Collection:
                 self._my_test_plan.append(t)
 
     def add_targets_to_plan_from_aliases_or_prefix_name(
-        self, alias_line: str = "", prefix_name: str = ""
+        self, alias_line: Optional[str] = None, prefix_name: Optional[str] = None
     ) -> None:
         """Add targets to the plan from aliases line or prefix name.
 
@@ -451,7 +451,9 @@ class Collection:
                 continue
             # Add the target to the plan if either the name starts with `prefix_name` or
             # The aliases file contains the line `alias_line`
-            if t.is_alias_of(alias_line) or t.name.startswith(prefix_name):
+            if (alias_line and t.is_alias_of(alias_line)) or (
+                prefix_name and t.name.startswith(prefix_name)
+            ):
                 self._my_test_plan.append(t)
 
     def add_indirect_node_count_targets_to_plan(self) -> None:

--- a/.github/actions/ansible_test_splitter/list_changed_common.py
+++ b/.github/actions/ansible_test_splitter/list_changed_common.py
@@ -272,6 +272,17 @@ class WhatHaveChanged:
         """
         yield from self._util_matches("plugins/plugin_utils/", "plugin_utils")
 
+    def extensions_audit_event_query(self) -> bool:
+        """Test if the extensions/audit/event_query.yml file has been updated.
+
+        :returns: whether the extensions/audit/event_query.yml file has been updated or not
+        """
+        event_query_files = (
+            "extensions/audit/event_query.yml",
+            "extensions/audit/event_query.yaml",
+        )
+        return any(str(d) in event_query_files for d in self.changed_files())
+
 
 class Target:
     """A class to store information about a specific target."""
@@ -426,6 +437,28 @@ class Collection:
         for t in self.targets():
             if t.is_alias_of(target_name) and self.is_candidate_target(t):
                 self._my_test_plan.append(t)
+
+    def add_targets_to_plan_from_aliases_or_prefix_name(
+        self, alias_line: str = "", prefix_name: str = ""
+    ) -> None:
+        """Add targets to the plan from aliases line or prefix name.
+
+        :param alias_line: target aliases file line
+        :param prefix_name: target prefix name
+        """
+        for t in self.targets():
+            if not self.is_candidate_target(t):
+                continue
+            # Add the target to the plan if either the name starts with `prefix_name` or
+            # The aliases file contains the line `alias_line`
+            if t.is_alias_of(alias_line) or t.name.startswith(prefix_name):
+                self._my_test_plan.append(t)
+
+    def add_indirect_node_count_targets_to_plan(self) -> None:
+        """Add indirect node count targets to the plan."""
+        alias_line = "indirect_node_count"
+        prefix_name = "node_query_"
+        self.add_targets_to_plan_from_aliases_or_prefix_name(alias_line, prefix_name)
 
     def cover_all(self) -> None:
         """Cover all the targets available."""

--- a/.github/actions/ansible_test_splitter/list_changed_targets.py
+++ b/.github/actions/ansible_test_splitter/list_changed_targets.py
@@ -120,7 +120,9 @@ class ListChangedTargets:
             # indirect node count targets
             if whc.extensions_audit_event_query():
                 for collection in collections:
-                    collection.add_indirect_node_count_targets_to_plan()
+                    # Add indirect node count targets only to the updated collection
+                    if collection.collection_name == whc.collection_name:
+                        collection.add_indirect_node_count_targets_to_plan()
 
         print("----------- Test plan      -----------")
         for collection in collections:

--- a/.github/actions/ansible_test_splitter/list_changed_targets.py
+++ b/.github/actions/ansible_test_splitter/list_changed_targets.py
@@ -8,6 +8,7 @@ from pathlib import PosixPath
 from typing import Dict
 from typing import List
 from typing import Union
+from typing import cast
 
 from list_changed_common import Collection
 from list_changed_common import ElGrandeSeparator
@@ -96,12 +97,18 @@ class ListChangedTargets:
                 "targets": [],
                 "roles": [],
             }
-            for path in whc.modules():
-                _add_changed_target(whc.collection_name, path, "modules")
-            for path in whc.inventory():
-                _add_changed_target(whc.collection_name, path, "inventory")
-            for path in whc.connection():
-                _add_changed_target(whc.collection_name, path, "connection")
+            for plugin_type, paths in (
+                ("modules", whc.modules()),
+                ("inventory", whc.inventory()),
+                ("connection", whc.connection()),
+                ("lookup", whc.lookup()),
+                ("targets", whc.targets()),
+                ("roles", whc.roles()),
+            ):
+                for path in paths:
+                    _add_changed_target(
+                        whc.collection_name, cast(Union[PosixPath, str], path), plugin_type
+                    )
             for path, pymod in whc.module_utils():
                 _add_changed_target(whc.collection_name, path, "module_utils")
                 for collection in collections:
@@ -110,12 +117,10 @@ class ListChangedTargets:
                 _add_changed_target(whc.collection_name, path, "plugin_utils")
                 for collection in collections:
                     collection.cover_module_utils(pymod, collections_names)
-            for path in whc.lookup():
-                _add_changed_target(whc.collection_name, path, "lookup")
-            for target in whc.targets():
-                _add_changed_target(whc.collection_name, target, "targets")
-            for role in whc.roles():
-                _add_changed_target(whc.collection_name, role, "roles")
+            # indirect node count targets
+            if whc.extensions_audit_event_query():
+                for collection in collections:
+                    collection.add_indirect_node_count_targets_to_plan()
 
         print("----------- Test plan      -----------")
         for collection in collections:


### PR DESCRIPTION
This PR introduces a new ability to trigger  indirect node count targets by ansible_test_splitter based on the following logic:

This action reads elements to test from the `extensions\audit` directory and corresponding tests from the `tests/integration/targets` directory. Here are more details on the relationship between `extensions\audit` and integration test targets:

- The test target name should have a prefix `node_query_` or define the `indirect_node_count` line in the `aliases` file, when the `event_query.yml` file changes.

This PR also fixes a pre-commit issue: `.github/actions/ansible_test_splitter/list_changed_targets.py:63:4: R0912: Too many branches (14/12) (too-many-branches)`  