### PR TITLE
feat(workflows): add ansible-core 2.21 to CI matrices

### DIFF
--- a/.github/workflows/integration_simple.yml
+++ b/.github/workflows/integration_simple.yml
@@ -14,11 +14,12 @@ on:
         # 2.18 supports Python 3.11-3.13
         # 2.19 supports Python 3.11-3.13
         # 2.20 supports Python 3.12-3.14
+        # 2.21 supports Python 3.12-3.14
         # support for Python 3.14 added and 3.11 removed in 2.20 for control node
         # target node supported Python 3.8-3.13 as of 2.18 and 2.19
         # target node supported Python 3.9-3.14 as of 2.20
-        # milestone is and devel is switched to 2.21
-        # https://docs.ansible.com/ansible/devel/roadmap/ROADMAP_2_20.html
+        # milestone is and devel is switched to 2.22
+        # https://docs.ansible.com/ansible/devel/roadmap/ROADMAP_2_21.html
         default: >-
           [
             {
@@ -27,6 +28,14 @@ on:
             },
             {
               "ansible-version": "devel",
+              "python-version": "3.10"
+            },
+            {
+              "ansible-version": "stable-2.21",
+              "python-version": "3.11"
+            },
+            {
+              "ansible-version": "stable-2.21",
               "python-version": "3.10"
             },
             {
@@ -95,18 +104,23 @@ jobs:
       matrix:
         ansible-version:
           # ansible-core 2.15 reached EOL on November 2024
-          # ansible-core 2.16 will reach EOL on May 2025
+          # ansible-core 2.16 reached EOL on May 2025
+          # ansible-core 2.17 reached EOL on November 2025
+          # However, we are keeping 2.16 and 2.17 in the matrix as multiple collections still support them
+          # ansible-core 2.18 will reach EOL on May 2026
           - stable-2.16
           - stable-2.17
           - stable-2.18
           - stable-2.19
           - stable-2.20
+          - stable-2.21
           - devel
         python-version:
           # 2.16 supports Python 3.10-3.11
           # 2.17 supports Python 3.10-3.12
           # 2.18 and 2.19 supports Python 3.11-3.13
           # 2.20 supports Python 3.12-3.14
+          # 2.21 supports Python 3.12-3.14
           - "3.10"
           - "3.11"
           - "3.12"

--- a/.github/workflows/integration_simple.yml
+++ b/.github/workflows/integration_simple.yml
@@ -14,11 +14,13 @@ on:
         # 2.18 supports Python 3.11-3.13
         # 2.19 supports Python 3.11-3.13
         # 2.20 supports Python 3.12-3.14
+        # 2.21 supports Python 3.12-3.14
         # support for Python 3.14 added and 3.11 removed in 2.20 for control node
         # target node supported Python 3.8-3.13 as of 2.18 and 2.19
-        # target node supported Python 3.9-3.14 as of 2.20
-        # milestone is and devel is switched to 2.21
-        # https://docs.ansible.com/ansible/devel/roadmap/ROADMAP_2_20.html
+        # target node supported Python 3.9-3.14 as of 2.20 and 2.21
+        # milestone and devel are switched to 2.22
+        # 2.22 supports Python 3.13-3.15 on the control node
+        # https://docs.ansible.com/ansible/devel/roadmap/ROADMAP_2_22.html
         default: >-
           [
             {
@@ -32,6 +34,14 @@ on:
             {
               "ansible-version": "devel",
               "python-version": "3.12"
+            },
+            {
+              "ansible-version": "stable-2.21",
+              "python-version": "3.11"
+            },
+            {
+              "ansible-version": "stable-2.21",
+              "python-version": "3.10"
             },
             {
               "ansible-version": "stable-2.20",
@@ -99,18 +109,22 @@ jobs:
       matrix:
         ansible-version:
           # ansible-core 2.15 reached EOL on November 2024
-          # ansible-core 2.16 will reach EOL on May 2025
+          # ansible-core 2.16 reached EOL on July 2025
+          # ansible-core 2.17 reached EOL on November 2025
+          # ansible-core 2.18 reached EOL on May 2026
+          # 2.16-2.18 are kept as several collections still support them
           - stable-2.16
           - stable-2.17
           - stable-2.18
           - stable-2.19
           - stable-2.20
+          - stable-2.21
           - devel
         python-version:
           # 2.16 supports Python 3.10-3.11
           # 2.17 supports Python 3.10-3.12
           # 2.18 and 2.19 supports Python 3.11-3.13
-          # 2.20 supports Python 3.12-3.14
+          # 2.20 and 2.21 supports Python 3.12-3.14
           - "3.10"
           - "3.11"
           - "3.12"

--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -14,11 +14,12 @@ on:
         # 2.18 supports Python 3.11-3.13
         # 2.19 supports Python 3.11-3.13
         # 2.20 supports Python 3.12-3.14
+        # 2.21 supports Python 3.12-3.14
         # support for Python 3.14 added and 3.11 removed in 2.20 for control node
         # target node supported Python 3.8-3.13 as of 2.18 and 2.19
         # target node supported Python 3.9-3.14 as of 2.20
-        # milestone is and devel is switched to 2.21
-        # https://docs.ansible.com/ansible/devel/roadmap/ROADMAP_2_20.html
+        # milestone is and devel is switched to 2.22
+        # https://docs.ansible.com/ansible/devel/roadmap/ROADMAP_2_21.html
         default: >-
           [
             {
@@ -27,6 +28,14 @@ on:
             },
             {
               "ansible-version": "devel",
+              "python-version": "3.10"
+            },
+            {
+              "ansible-version": "stable-2.21",
+              "python-version": "3.11"
+            },
+            {
+              "ansible-version": "stable-2.21",
               "python-version": "3.10"
             },
             {
@@ -101,18 +110,23 @@ jobs:
           - ubuntu-latest
         ansible-version:
           # ansible-core 2.15 reached EOL on November 2024
-          # ansible-core 2.16 will reach EOL on May 2025
+          # ansible-core 2.16 reached EOL on May 2025
+          # ansible-core 2.17 reached EOL on November 2025
+          # However, we are keeping 2.16 and 2.17 in the matrix as multiple collections still support them
+          # ansible-core 2.18 will reach EOL on May 2026
           - stable-2.16
           - stable-2.17
           - stable-2.18
           - stable-2.19
           - stable-2.20
+          - stable-2.21
           - devel
         python-version:
           # 2.16 supports Python 3.10-3.11
           # 2.17 supports Python 3.10-3.12
           # 2.18 and 2.19 supports Python 3.11-3.13
           # 2.20 supports Python 3.12-3.14
+          # 2.21 supports Python 3.12-3.14
           - "3.10"
           - "3.11"
           - "3.12"

--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -14,11 +14,13 @@ on:
         # 2.18 supports Python 3.11-3.13
         # 2.19 supports Python 3.11-3.13
         # 2.20 supports Python 3.12-3.14
+        # 2.21 supports Python 3.12-3.14
         # support for Python 3.14 added and 3.11 removed in 2.20 for control node
         # target node supported Python 3.8-3.13 as of 2.18 and 2.19
-        # target node supported Python 3.9-3.14 as of 2.20
-        # milestone is and devel is switched to 2.21
-        # https://docs.ansible.com/ansible/devel/roadmap/ROADMAP_2_20.html
+        # target node supported Python 3.9-3.14 as of 2.20 and 2.21
+        # milestone and devel are switched to 2.22
+        # 2.22 supports Python 3.13-3.15 on the control node
+        # https://docs.ansible.com/ansible/devel/roadmap/ROADMAP_2_22.html
         default: >-
           [
             {
@@ -113,7 +115,10 @@ jobs:
           - ubuntu-latest
         ansible-version:
           # ansible-core 2.15 reached EOL on November 2024
-          # ansible-core 2.16 will reach EOL on May 2025
+          # ansible-core 2.16 reached EOL on July 2025
+          # ansible-core 2.17 reached EOL on November 2025
+          # ansible-core 2.18 reached EOL on May 2026
+          # 2.16-2.18 are kept as several collections still support them
           - stable-2.16
           - stable-2.17
           - stable-2.18
@@ -125,7 +130,7 @@ jobs:
           # 2.16 supports Python 3.10-3.11
           # 2.17 supports Python 3.10-3.12
           # 2.18 and 2.19 supports Python 3.11-3.13
-          # 2.20 supports Python 3.12-3.14
+          # 2.20 and 2.21 supports Python 3.12-3.14
           - "3.10"
           - "3.11"
           - "3.12"

--- a/.github/workflows/unit_galaxy.yml
+++ b/.github/workflows/unit_galaxy.yml
@@ -14,11 +14,12 @@ on:
         # 2.18 supports Python 3.11-3.13
         # 2.19 supports Python 3.11-3.13
         # 2.20 supports Python 3.12-3.14
+        # 2.21 supports Python 3.12-3.14
         # support for Python 3.14 added and 3.11 removed in 2.20 for control node
         # target node supported Python 3.8-3.13 as of 2.18 and 2.19
         # target node supported Python 3.9-3.14 as of 2.20
-        # milestone is and devel is switched to 2.21
-        # https://docs.ansible.com/ansible/devel/roadmap/ROADMAP_2_20.html
+        # milestone is and devel is switched to 2.22
+        # https://docs.ansible.com/ansible/devel/roadmap/ROADMAP_2_21.html
         default: >-
           [
             {
@@ -27,6 +28,14 @@ on:
             },
             {
               "ansible-version": "devel",
+              "python-version": "3.10"
+            },
+            {
+              "ansible-version": "stable-2.21",
+              "python-version": "3.11"
+            },
+            {
+              "ansible-version": "stable-2.21",
               "python-version": "3.10"
             },
             {
@@ -92,18 +101,23 @@ jobs:
       matrix:
         ansible-version:
           # ansible-core 2.15 reached EOL on November 2024
-          # ansible-core 2.16 will reach EOL on May 2025
+          # ansible-core 2.16 reached EOL on May 2025
+          # ansible-core 2.17 reached EOL on November 2025
+          # However, we are keeping 2.16 and 2.17 in the matrix as multiple collections still support them
+          # ansible-core 2.18 will reach EOL on May 2026
           - stable-2.16
           - stable-2.17
           - stable-2.18
           - stable-2.19
           - stable-2.20
+          - stable-2.21
           - devel
         python-version:
           # 2.16 supports Python 3.10-3.11
           # 2.17 supports Python 3.10-3.12
           # 2.18 and 2.19 supports Python 3.11-3.13
           # 2.20 supports Python 3.12-3.14
+          # 2.21 supports Python 3.12-3.14
           - "3.10"
           - "3.11"
           - "3.12"

--- a/.github/workflows/unit_galaxy.yml
+++ b/.github/workflows/unit_galaxy.yml
@@ -14,11 +14,13 @@ on:
         # 2.18 supports Python 3.11-3.13
         # 2.19 supports Python 3.11-3.13
         # 2.20 supports Python 3.12-3.14
+        # 2.21 supports Python 3.12-3.14
         # support for Python 3.14 added and 3.11 removed in 2.20 for control node
         # target node supported Python 3.8-3.13 as of 2.18 and 2.19
-        # target node supported Python 3.9-3.14 as of 2.20
-        # milestone is and devel is switched to 2.21
-        # https://docs.ansible.com/ansible/devel/roadmap/ROADMAP_2_20.html
+        # target node supported Python 3.9-3.14 as of 2.20 and 2.21
+        # milestone and devel are switched to 2.22
+        # 2.22 supports Python 3.13-3.15 on the control node
+        # https://docs.ansible.com/ansible/devel/roadmap/ROADMAP_2_22.html
         default: >-
           [
             {
@@ -32,6 +34,14 @@ on:
             {
               "ansible-version": "devel",
               "python-version": "3.12"
+            },
+            {
+              "ansible-version": "stable-2.21",
+              "python-version": "3.11"
+            },
+            {
+              "ansible-version": "stable-2.21",
+              "python-version": "3.10"
             },
             {
               "ansible-version": "stable-2.20",
@@ -96,18 +106,22 @@ jobs:
       matrix:
         ansible-version:
           # ansible-core 2.15 reached EOL on November 2024
-          # ansible-core 2.16 will reach EOL on May 2025
+          # ansible-core 2.16 reached EOL on July 2025
+          # ansible-core 2.17 reached EOL on November 2025
+          # ansible-core 2.18 reached EOL on May 2026
+          # 2.16-2.18 are kept as several collections still support them
           - stable-2.16
           - stable-2.17
           - stable-2.18
           - stable-2.19
           - stable-2.20
+          - stable-2.21
           - devel
         python-version:
           # 2.16 supports Python 3.10-3.11
           # 2.17 supports Python 3.10-3.12
           # 2.18 and 2.19 supports Python 3.11-3.13
-          # 2.20 supports Python 3.12-3.14
+          # 2.20 and 2.21 supports Python 3.12-3.14
           - "3.10"
           - "3.11"
           - "3.12"

--- a/.github/workflows/unit_source.yml
+++ b/.github/workflows/unit_source.yml
@@ -14,11 +14,12 @@ on:
         # 2.18 supports Python 3.11-3.13
         # 2.19 supports Python 3.11-3.13
         # 2.20 supports Python 3.12-3.14
+        # 2.21 supports Python 3.12-3.14
         # support for Python 3.14 added and 3.11 removed in 2.20 for control node
         # target node supported Python 3.8-3.13 as of 2.18 and 2.19
         # target node supported Python 3.9-3.14 as of 2.20
-        # milestone is and devel is switched to 2.21
-        # https://docs.ansible.com/ansible/devel/roadmap/ROADMAP_2_20.html
+        # milestone is and devel is switched to 2.22
+        # https://docs.ansible.com/ansible/devel/roadmap/ROADMAP_2_21.html
         default: >-
           [
             {
@@ -47,6 +48,14 @@ on:
             },
             {
               "ansible-version": "milestone",
+              "python-version": "3.10"
+            },
+            {
+              "ansible-version": "stable-2.21",
+              "python-version": "3.11"
+            },
+            {
+              "ansible-version": "stable-2.21",
               "python-version": "3.10"
             },
             {
@@ -108,18 +117,23 @@ jobs:
       matrix:
         ansible-version:
           # ansible-core 2.15 reached EOL on November 2024
-          # ansible-core 2.16 will reach EOL on May 2025
+          # ansible-core 2.16 reached EOL on May 2025
+          # ansible-core 2.17 reached EOL on November 2025
+          # However, we are keeping 2.16 and 2.17 in the matrix as multiple collections still support them
+          # ansible-core 2.18 will reach EOL on May 2026
           - stable-2.16
           - stable-2.17
           - stable-2.18
           - stable-2.19
           - stable-2.20
+          - stable-2.21
           - devel
         python-version:
           # 2.16 supports Python 3.10-3.11
           # 2.17 supports Python 3.10-3.12
           # 2.18 and 2.19 supports Python 3.11-3.13
           # 2.20 supports Python 3.12-3.14
+          # 2.21 supports Python 3.12-3.14
           - "3.10"
           - "3.11"
           - "3.12"

--- a/.github/workflows/unit_source.yml
+++ b/.github/workflows/unit_source.yml
@@ -14,11 +14,13 @@ on:
         # 2.18 supports Python 3.11-3.13
         # 2.19 supports Python 3.11-3.13
         # 2.20 supports Python 3.12-3.14
+        # 2.21 supports Python 3.12-3.14
         # support for Python 3.14 added and 3.11 removed in 2.20 for control node
         # target node supported Python 3.8-3.13 as of 2.18 and 2.19
-        # target node supported Python 3.9-3.14 as of 2.20
-        # milestone is and devel is switched to 2.21
-        # https://docs.ansible.com/ansible/devel/roadmap/ROADMAP_2_20.html
+        # target node supported Python 3.9-3.14 as of 2.20 and 2.21
+        # milestone and devel are switched to 2.22
+        # 2.22 supports Python 3.13-3.15 on the control node
+        # https://docs.ansible.com/ansible/devel/roadmap/ROADMAP_2_22.html
         default: >-
           [
             {
@@ -120,7 +122,10 @@ jobs:
       matrix:
         ansible-version:
           # ansible-core 2.15 reached EOL on November 2024
-          # ansible-core 2.16 will reach EOL on May 2025
+          # ansible-core 2.16 reached EOL on July 2025
+          # ansible-core 2.17 reached EOL on November 2025
+          # ansible-core 2.18 reached EOL on May 2026
+          # 2.16-2.18 are kept as several collections still support them
           - stable-2.16
           - stable-2.17
           - stable-2.18
@@ -132,7 +137,7 @@ jobs:
           # 2.16 supports Python 3.10-3.11
           # 2.17 supports Python 3.10-3.12
           # 2.18 and 2.19 supports Python 3.11-3.13
-          # 2.20 supports Python 3.12-3.14
+          # 2.20 and 2.21 supports Python 3.12-3.14
           - "3.10"
           - "3.11"
           - "3.12"


### PR DESCRIPTION
# Summary

Ansible 2.21 went GA in May 2026 and milestone/devel have moved on to 2.22, so this repo must be updated to allow all down repo's have proper testing. 

This PR was created before #194, so after rebase, half of the changes disappeared. Anyway, this one still worth to have as it updates `unit_galaxy.yml` and `integration_simple.yml` and outdated comments in `sanity.yml` and `unit_source.yml`

| workflow | before | after |
| --- | --- | --- |
| `sanity.yml` | 2.16 – 2.21 + devel | unchanged (comments only) |
| `unit_source.yml` | 2.16 – 2.21 + devel | unchanged (comments only) |
| `unit_galaxy.yml` | 2.16 – 2.20 + devel | **2.16 – 2.21 + devel** |
| `integration_simple.yml` | 2.16 – 2.20 + devel | **2.16 – 2.21 + devel** |

`stable-2.21` is excluded on Python 3.10 and 3.11, so it runs on 3.12 / 3.13 / 3.14 (the same control-node range as 2.20, per the [ansible-core support matrix](https://docs.ansible.com/ansible-core/devel/reference_appendices/release_and_maintenance.html#ansible-core-support-matrix). That matches the excludes #194 already added for 2.21 in the other two workflows.
