### PR TITLE
Update sanity and unit tests matrix with stable-2.21

### DIFF
--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -30,6 +30,14 @@ on:
               "python-version": "3.10"
             },
             {
+              "ansible-version": "stable-2.21",
+              "python-version": "3.11"
+            },
+            {
+              "ansible-version": "stable-2.21",
+              "python-version": "3.10"
+            },
+            {
               "ansible-version": "stable-2.20",
               "python-version": "3.11"
             },
@@ -107,6 +115,7 @@ jobs:
           - stable-2.18
           - stable-2.19
           - stable-2.20
+          - stable-2.21
           - devel
         python-version:
           # 2.16 supports Python 3.10-3.11

--- a/.github/workflows/unit_source.yml
+++ b/.github/workflows/unit_source.yml
@@ -50,6 +50,14 @@ on:
               "python-version": "3.10"
             },
             {
+              "ansible-version": "stable-2.21",
+              "python-version": "3.11"
+            },
+            {
+              "ansible-version": "stable-2.21",
+              "python-version": "3.10"
+            },
+            {
               "ansible-version": "stable-2.20",
               "python-version": "3.11"
             },
@@ -114,6 +122,7 @@ jobs:
           - stable-2.18
           - stable-2.19
           - stable-2.20
+          - stable-2.21
           - devel
         python-version:
           # 2.16 supports Python 3.10-3.11


### PR DESCRIPTION
Stable-2.21 has been created in the Ansible upstream repository. Update the sanity and unit tests matrix to reflect the change.