### PR TITLE
Update pre-commit hooks for Python 3.14 compatibility

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 ---
 repos:
   - repo: https://github.com/PyCQA/isort
-    rev: 5.13.2
+    rev: 6.0.0
     hooks:
       - id: isort
         args: ["--filter-files"]
@@ -15,7 +15,7 @@ repos:
           - prettier-plugin-toml
 
   - repo: https://github.com/psf/black
-    rev: 24.4.2
+    rev: 25.1.0
     hooks:
       - id: black
 
@@ -25,7 +25,7 @@ repos:
       - id: remove-tabs
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v5.0.0
     hooks:
       - id: trailing-whitespace
       - id: check-merge-conflict
@@ -35,29 +35,29 @@ repos:
       - id: debug-statements
 
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.3.0
+    rev: v2.4.1
     hooks:
       - id: codespell
 
   - repo: https://github.com/pycqa/flake8
-    rev: 7.1.0
+    rev: 7.1.2
     hooks:
       - id: flake8
         additional_dependencies:
           - darglint
           - flake8-2020 >= 1.6.0
-          - flake8-docstrings # uses pydocstyle
+          - flake8-docstrings
           - flake8-isort >= 4.1.1
 
   - repo: https://github.com/asottile/pyupgrade
     # keep it after flake8
-    rev: v3.16.0
+    rev: v3.19.1
     hooks:
       - id: pyupgrade
         args: ["--py39-plus"]
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.10.0
+    rev: v1.15.0
     hooks:
       - id: mypy
         additional_dependencies:
@@ -67,7 +67,7 @@ repos:
           - types-requests
 
   - repo: https://github.com/pycqa/pylint
-    rev: v3.2.3
+    rev: v3.3.4
     hooks:
       - id: pylint
         additional_dependencies:


### PR DESCRIPTION
### Description

Updates several hook versions in `pre-commit-config.yaml` to fix CI build failures on `pre-commit.ci` caused by upstream changes in the Python 3.14 environment.

### Changes
* **`pyupgrade`**: Bumped from `v3.16.0` to `v3.19.1` to resolve an internal tokenizing crash (`TypeError: cannot use a bytes pattern on a string-like object`).
* **`pylint`**: Bumped from `v3.2.3` to `v3.3.4` to fix false-positive standard library import errors (`collections.abc`).
* **General Ecosystem**: Refreshed other core hooks (`black`, `isort`, `mypy`, `pre-commit-hooks`) to modern versions to ensure overall health and stability across test suites.