### PR TITLE
excluded python 3.12 for ansible core devel branch

### DIFF
--- a/.github/workflows/unit_source.yml
+++ b/.github/workflows/unit_source.yml
@@ -17,13 +17,18 @@ on:
         # support for Python 3.14 added and 3.11 removed in 2.20 for control node
         # target node supported Python 3.8-3.13 as of 2.18 and 2.19
         # target node supported Python 3.9-3.14 as of 2.20
-        # milestone is and devel is switched to 2.21
+        # milestone and devel is switched to 2.22
+        # 2.22 supports Python 3.13-3.15
         # https://docs.ansible.com/ansible/devel/roadmap/ROADMAP_2_20.html
         default: >-
           [
             {
               "ansible-version": "devel",
               "python-version": "3.11"
+            },
+            {
+              "ansible-version": "devel",
+              "python-version": "3.12"
             },
             {
               "ansible-version": "devel",

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,7 +51,7 @@ repos:
 
   - repo: https://github.com/asottile/pyupgrade
     # keep it after flake8
-    rev: v3.16.0
+    rev: v3.21.2
     hooks:
       - id: pyupgrade
         args: ["--py39-plus"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ max-line-length = 100
 
 [tool.pylint.master]
 no-docstring-rgx = "__.*__"
+py-version = "3.9"
 
 [tool.pylint.messages_control]
 disable = ["fixme"]


### PR DESCRIPTION
excluded python 3.12 for ansible core devel branch  from .github/workflows/unit_source.yml workflow as devel branch does not support python 3.12