### PR TITLE
Exclude ansible-core devel + Python < 3.13 across all reusable workflows

### DIFF
--- a/.github/workflows/integration_simple.yml
+++ b/.github/workflows/integration_simple.yml
@@ -30,6 +30,10 @@ on:
               "python-version": "3.10"
             },
             {
+              "ansible-version": "devel",
+              "python-version": "3.12"
+            },
+            {
               "ansible-version": "stable-2.20",
               "python-version": "3.11"
             },

--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -30,6 +30,10 @@ on:
               "python-version": "3.10"
             },
             {
+              "ansible-version": "devel",
+              "python-version": "3.12"
+            },
+            {
               "ansible-version": "stable-2.21",
               "python-version": "3.11"
             },

--- a/.github/workflows/unit_galaxy.yml
+++ b/.github/workflows/unit_galaxy.yml
@@ -30,6 +30,10 @@ on:
               "python-version": "3.10"
             },
             {
+              "ansible-version": "devel",
+              "python-version": "3.12"
+            },
+            {
               "ansible-version": "stable-2.20",
               "python-version": "3.11"
             },


### PR DESCRIPTION
##### SUMMARY

ansible-core `devel` (2.21) dropped Python 3.12 control-node support and now declares `requires-python = ">=3.13"` (ansible/ansible#87057, merged 2026-06-05). Any reusable workflow that still pairs `devel` with Python 3.12 fails while installing ansible-core:

ERROR: Package 'ansible-core' requires a different Python: 3.12.x not in '>=3.13'
Error: Process completed with exit code 1.

`unit_source.yml` already excluded `devel` + 3.12. This PR applies the same exclusion to the remaining workflows that schedule `devel`, so `devel` only ever runs on Python >= 3.13.

##### CHANGES

Added `{"ansible-version": "devel", "python-version": "3.12"}` to the default `matrix_exclude` of:

- `sanity.yml`
- `unit_galaxy.yml`
- `integration_simple.yml`

`integration.yml` keeps `devel` commented out in its matrix, so it needs no change. `unit_source.yml` was already correct.

After this change, every workflow excludes `devel` for all Python < 3.13 (3.10, 3.11, 3.12).

##### WHY HERE (not downstream)

Downstream collections (e.g. ansible-collections/kubernetes.core#1145) consume these reusable workflows via `@main` with no matrix overrides, so the fix belongs in this repo.

##### REFERENCES

- ansible/ansible#87057 — "Drop Python 3.12 controller support"
- `devel/pyproject.toml`: `requires-python = ">=3.13"`
- Downstream report: ansible-collections/kubernetes.core#1145

Fixes #199