### PR TITLE
fix(ci): update pre-commit hooks for Python 3.14

### DIFF
--- a/.github/actions/tox/install_packages.py
+++ b/.github/actions/tox/install_packages.py
@@ -24,7 +24,7 @@ logger = logging.getLogger("install_sibling")
 logger.setLevel(logging.DEBUG)
 
 
-# pylint: disable-next=too-many-arguments
+# pylint: disable-next=too-many-arguments,too-many-positional-arguments
 def run_tox_command(
     project_dir: PosixPath,
     env_name: Optional[str],

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,7 +51,7 @@ repos:
 
   - repo: https://github.com/asottile/pyupgrade
     # keep it after flake8
-    rev: v3.16.0
+    rev: v3.21.2
     hooks:
       - id: pyupgrade
         args: ["--py39-plus"]
@@ -67,7 +67,7 @@ repos:
           - types-requests
 
   - repo: https://github.com/pycqa/pylint
-    rev: v3.2.3
+    rev: v3.3.9
     hooks:
       - id: pylint
         additional_dependencies:


### PR DESCRIPTION
# Summary

This is a targeted fix for the `pre-commit.ci` failure tracked in #201.

It updates the two hooks that break under the Python 3.14 runtime used by `pre-commit.ci`:

- `pyupgrade` from `v3.16.0` to `v3.21.2`
- `pylint` from `v3.2.3` to `v3.3.9`

The newer pylint release also emits `too-many-positional-arguments` for `run_tox_command()`, so this PR extends the existing local pylint suppression for that helper.

# Why

The current CI failure is not caused by application logic. It is caused by hook/runtime incompatibility:

- `pyupgrade` crashes with `TypeError: cannot use a bytes pattern on a string-like object`
- `pylint` reports `E0401: Unable to import 'collections.abc'`

This PR updates only the components needed to unblock the failing check while keeping the scope narrow.

# Additional context

PR #197 by @mjohns91 updates several pre-commit hooks for Python 3.14 compatibility and is closely related. That work appears directionally correct, but it does not resolve the `pyupgrade` failure from the failing `pre-commit.ci` run linked in #201. This PR focuses on the minimal change set that addresses the currently failing hooks.