### PR TITLE
Add allow-unsafe-pr-checkout as true for checkout_dependency

### DIFF
--- a/.github/actions/checkout_dependency/action.yml
+++ b/.github/actions/checkout_dependency/action.yml
@@ -46,3 +46,4 @@ runs:
         path: ${{ inputs.path }}
         ref: ${{ steps.resolve-dependency.outputs.merge_commit_sha || inputs.ref }}
         fetch-depth: ${{ inputs.fetch-depth }}
+        allow-unsafe-pr-checkout: true


### PR DESCRIPTION
CML Integration tests are failing with 
```
Refusing to check out fork pull request code from a 'pull_request_target' workflow. This workflow runs with the base repository's GITHUB_TOKEN, secrets, default-branch cache scope, and runner access. Fetching and executing a fork's code in that trusted context commonly leads to "pwn request" vulnerabilities. To opt in, review the risks at https://gh.io/securely-using-pull_request_target and set 'allow-unsafe-pr-checkout: true' on the actions/checkout step.
```

The following adds one of the suggested items to the code to allow unsafe-pr-checkout